### PR TITLE
UTIL - improvements/bug fixing | FRAMEWORK - bug fix to set parentCentralStore for tagStore

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ UTILS:
 address-merger | merge TAG before duplicate object is deleted
 
 BUGFIX:
-
+PanoramaConf | fix for TagStore to set parentCentralStore at time of reading DG hierarchy - example usage pa_rule-edit actions=tag-add:TAGNAME (if TAGNAME is defined NOT at shared but at parent DG)
 
 
 2.0.0 (20210426)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ GENERAL:
 
 UTILS:
 address-merger | merge TAG before duplicate object is deleted
+schedule-edit | introduce new util tool
 
 BUGFIX:
 PanoramaConf | fix for TagStore to set parentCentralStore at time of reading DG hierarchy - example usage pa_rule-edit actions=tag-add:TAGNAME (if TAGNAME is defined NOT at shared but at parent DG)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ GENERAL:
 * introduce again travis for automatic unit testing
 
 UTILS:
-
+address-merger | merge TAG before duplicate object is deleted
 
 BUGFIX:
 

--- a/README.md
+++ b/README.md
@@ -83,30 +83,30 @@ Utility script 'rules-edit.php' is a swiss knife to edit rules and takes advanta
 
 Do you want to enable log at start for rule going to DMZ zone and that has only object group 'Webfarms' as a destination ?
 
-    rules-edit.php in=api://fw1.mycompany.com actions=logStart-Enable 'filter=(to has dmz) and (dst has.only Webfarms)'
+    pa_rule-edit in=api://fw1.mycompany.com actions=logStart-Enable 'filter=(to has dmz) and (dst has.only Webfarms)'
 
 You are not sure about your filter and want to see rules before making changes ? Use action 'display' :
 
-    rules-edit.php  in=api://fw1.mycompany.com actions=display 'filter=(to has dmz) and (dst has.only Webfarms)'
+    pa_rule-edit  in=api://fw1.mycompany.com actions=display 'filter=(to has dmz) and (dst has.only Webfarms)'
 
 Change all rules using Application + Any service to application default ?
 
-    rules-edit.php in=api://fw1.mycompany.com actions=service-Set-AppDefault 'filter=!(app is.any) and (service is.any)'
+    pa_rule-edit in=api://fw1.mycompany.com actions=service-Set-AppDefault 'filter=!(app is.any) and (service is.any)'
 
 Move post-SecurityRules with source zone 'dmz' or source object 'Admin-networks' to pre-Security rule ?
 
-    rules-edit.php  in=api://panorama.mycompany.com actions=invertPreAndPost 'filter=((from has dmz) or (source has Admin-networks) and (rule is.postrule))'
+    pa_rule-edit  in=api://panorama.mycompany.com actions=invertPreAndPost 'filter=((from has dmz) or (source has Admin-networks) and (rule is.postrule))'
 
 Want to know what actions are supported ?
 
-    rules-edit.php  listActions
-    rules-edit.php listFilters
+    pa_rule-edit  listActions
+    pa_rule-edit listFilters
 
 **UTIL plugin** 
 
 The UTIL scripts rules-edit/address-edit/service-edit/tag-edit can be easily and flexible extend by writing your own plugin:
 
-- rules-edit actions plugin example:
+- pa_rule-edit actions plugin example:
 ```php
     RuleCallContext::$supportedActions[] = Array(
         'name' => 'schedule_remove_update_desc',
@@ -133,7 +133,7 @@ The UTIL scripts rules-edit/address-edit/service-edit/tag-edit can be easily and
     );
 ```
 
-- rules-edit filter plugin example:
+- pa_rule-edit filter plugin example:
 ```php
 RQuery::$defaultFilters['rule']['description']['operators']['is.geq'] = Array(
     'Function' => function(RuleRQueryContext $context )
@@ -150,6 +150,14 @@ RQuery::$defaultFilters['rule']['description']['operators']['is.geq'] = Array(
 - plugin usage from above for rule:
 
     rules-edit.php  in=api://panorama.mycompany.com loadplugin=your_plugin_file.php ['actions=YOUR_PLUGIN_ACTION_NAME'] ['filter=(YOUR_PLUGIN_FILTER_NAME)']
+
+**UTIL usage via API** 
+- PAN-OS API-KEYs are stored automatically at file: '.panconfkeystore' in your Systems User folder at the first time using a script with connection type API
+- or you can manage your API-KEY store with UTIL script pa_key-manager:
+```php
+    pa_key-manager add=MGMT-IP
+    pa_key-manager delete=MGMT-IP
+```
 
 
 **Available UTIL scripts, provided by Alias:**
@@ -169,7 +177,6 @@ RQuery::$defaultFilters['rule']['description']['operators']['is.geq'] = Array(
 - pa_download-predefined
 - pa_key-manager
 - pa_override-finder
-- pa_panorama-2-fawkes
 - pa_panos-xml-issue-detector
 - pa_register-ip-mgr
 - pa_rule-edit

--- a/lib/device-and-system-classes/DeviceCloud.php
+++ b/lib/device-and-system-classes/DeviceCloud.php
@@ -290,6 +290,9 @@ class DeviceCloud
                 $this->parentContainer = $parentContainer;
                 $this->addressStore->parentCentralStore = $parentContainer->addressStore;
                 $this->serviceStore->parentCentralStore = $parentContainer->serviceStore;
+                $this->tagStore->parentCentralStore = $parentContainer->tagStore;
+                //Todo: swaschkut 20210505 - check if other Stores must be added
+                //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
             }
         }
 

--- a/lib/device-and-system-classes/FawkesConf.php
+++ b/lib/device-and-system-classes/FawkesConf.php
@@ -318,6 +318,8 @@ class FawkesConf
                     $ldv->addressStore->parentCentralStore = $parentContainer->addressStore;
                     $ldv->serviceStore->parentCentralStore = $parentContainer->serviceStore;
                     $ldv->tagStore->parentCentralStore = $parentContainer->tagStore;
+                    //Todo: swaschkut 20210505 - check if other Stores must be added
+                    //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
                 }
             }
             
@@ -774,14 +776,14 @@ class FawkesConf
      * @param string $name
      * @return Container
      **/
-    public function createContainer($name, $parentContainer)
+    public function createContainer($name, $parentContainerName)
     {
         $newDG = new Container($this);
         $newDG->load_from_templateContainerXml();
         $newDG->setName($name);
 
         $parentNode = DH::findFirstElementOrCreate('parent', $newDG->xmlroot );
-        DH::setDomNodeText($parentNode, $parentContainer );
+        DH::setDomNodeText($parentNode, $parentContainerName );
 
         $this->containers[] = $newDG;
 
@@ -809,15 +811,18 @@ class FawkesConf
             $dgMetaDataNode->appendChild($newXmlNode);
         }
 
-        $parentContainer = $this->findContainer( $parentContainer );
+        $parentContainer = $this->findContainer( $parentContainerName );
         if( $parentContainer === null )
-            mwarning("Container '$name' has Container '{$parentContainer}' listed as parent but it cannot be found in XML");
+            mwarning("Container '$name' has Container '{$parentContainerName}' listed as parent but it cannot be found in XML");
         else
         {
             $parentContainer->_childContainers[$name] = $newDG;
             $newDG->parentContainer = $parentContainer;
             $newDG->addressStore->parentCentralStore = $parentContainer->addressStore;
             $newDG->serviceStore->parentCentralStore = $parentContainer->serviceStore;
+            $newDG->tagStore->parentCentralStore = $parentContainer->tagStore;
+            //Todo: swaschkut 20210505 - check if other Stores must be added
+            //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
         }
 
         return $newDG;
@@ -887,6 +892,9 @@ class FawkesConf
             $newDG->parentContainer = $parentContainer;
             $newDG->addressStore->parentCentralStore = $parentContainer->addressStore;
             $newDG->serviceStore->parentCentralStore = $parentContainer->serviceStore;
+            $newDG->tagStore->parentCentralStore = $parentContainer->tagStore;
+            //Todo: swaschkut 20210505 - check if other Stores must be added
+            //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
         }
 
         return $newDG;

--- a/lib/device-and-system-classes/FawkesConf.php
+++ b/lib/device-and-system-classes/FawkesConf.php
@@ -318,6 +318,7 @@ class FawkesConf
                     $ldv->addressStore->parentCentralStore = $parentContainer->addressStore;
                     $ldv->serviceStore->parentCentralStore = $parentContainer->serviceStore;
                     $ldv->tagStore->parentCentralStore = $parentContainer->tagStore;
+                    $ldv->scheduleStore->parentCentralStore = $parentContainer->scheduleStore;
                     //Todo: swaschkut 20210505 - check if other Stores must be added
                     //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
                 }
@@ -821,6 +822,7 @@ class FawkesConf
             $newDG->addressStore->parentCentralStore = $parentContainer->addressStore;
             $newDG->serviceStore->parentCentralStore = $parentContainer->serviceStore;
             $newDG->tagStore->parentCentralStore = $parentContainer->tagStore;
+            $newDG->scheduleStore->parentCentralStore = $parentContainer->scheduleStore;
             //Todo: swaschkut 20210505 - check if other Stores must be added
             //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
         }
@@ -893,6 +895,7 @@ class FawkesConf
             $newDG->addressStore->parentCentralStore = $parentContainer->addressStore;
             $newDG->serviceStore->parentCentralStore = $parentContainer->serviceStore;
             $newDG->tagStore->parentCentralStore = $parentContainer->tagStore;
+            $newDG->scheduleStore->parentCentralStore = $parentContainer->scheduleStore;
             //Todo: swaschkut 20210505 - check if other Stores must be added
             //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
         }

--- a/lib/device-and-system-classes/FawkesConf.php
+++ b/lib/device-and-system-classes/FawkesConf.php
@@ -317,6 +317,7 @@ class FawkesConf
                     $ldv->parentContainer = $parentContainer;
                     $ldv->addressStore->parentCentralStore = $parentContainer->addressStore;
                     $ldv->serviceStore->parentCentralStore = $parentContainer->serviceStore;
+                    $ldv->tagStore->parentCentralStore = $parentContainer->tagStore;
                 }
             }
             

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -904,6 +904,8 @@ class PanoramaConf
                         $ldv->addressStore->parentCentralStore = $parentDG->addressStore;
                         $ldv->serviceStore->parentCentralStore = $parentDG->serviceStore;
                         $ldv->tagStore->parentCentralStore = $parentDG->tagStore;
+                        //Todo: swaschkut 20210505 - check if other Stores must be added
+                        //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
                     }
                 }
 
@@ -1350,7 +1352,7 @@ class PanoramaConf
      * @param string $name
      * @return DeviceGroup
      **/
-    public function createDeviceGroup($name)
+    public function createDeviceGroup($name, $parentDGname = null )
     {
         $newDG = new DeviceGroup($this);
         $newDG->load_from_templateXml();
@@ -1380,6 +1382,23 @@ class PanoramaConf
                 $newXmlNode = DH::importXmlStringOrDie($this->xmldoc, "<entry name=\"{$name}\"><dg-id>{$dgMaxID}</dg-id></entry>");
 
             $dgMetaDataNode->appendChild($newXmlNode);
+        }
+
+        if( $parentDGname !== null )
+        {
+            $parentDG = $this->findDeviceGroup( $parentDGname );
+            if( $parentDG === null )
+                mwarning("DeviceGroup '$name' has Container '{$parentDGname}' listed as parent but it cannot be found in XML");
+            else
+            {
+                $parentDG->_childDeviceGroups[$name] = $newDG;
+                $newDG->parentDeviceGroup = $parentDG;
+                $newDG->addressStore->parentCentralStore = $parentDG->addressStore;
+                $newDG->serviceStore->parentCentralStore = $parentDG->serviceStore;
+                $newDG->tagStore->parentCentralStore = $parentDG->tagStore;
+                //Todo: swaschkut 20210505 - check if other Stores must be added
+                //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
+            }
         }
 
         return $newDG;

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -903,6 +903,7 @@ class PanoramaConf
                         $ldv->parentDeviceGroup = $parentDG;
                         $ldv->addressStore->parentCentralStore = $parentDG->addressStore;
                         $ldv->serviceStore->parentCentralStore = $parentDG->serviceStore;
+                        $ldv->tagStore->parentCentralStore = $parentDG->tagStore;
                     }
                 }
 

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -904,6 +904,7 @@ class PanoramaConf
                         $ldv->addressStore->parentCentralStore = $parentDG->addressStore;
                         $ldv->serviceStore->parentCentralStore = $parentDG->serviceStore;
                         $ldv->tagStore->parentCentralStore = $parentDG->tagStore;
+                        $ldv->scheduleStore->parentCentralStore = $parentDG->scheduleStore;
                         //Todo: swaschkut 20210505 - check if other Stores must be added
                         //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
                     }
@@ -1388,7 +1389,7 @@ class PanoramaConf
         {
             $parentDG = $this->findDeviceGroup( $parentDGname );
             if( $parentDG === null )
-                mwarning("DeviceGroup '$name' has Container '{$parentDGname}' listed as parent but it cannot be found in XML");
+                mwarning("DeviceGroup '$name' has DeviceGroup '{$parentDGname}' listed as parent but it cannot be found in XML");
             else
             {
                 $parentDG->_childDeviceGroups[$name] = $newDG;
@@ -1396,6 +1397,7 @@ class PanoramaConf
                 $newDG->addressStore->parentCentralStore = $parentDG->addressStore;
                 $newDG->serviceStore->parentCentralStore = $parentDG->serviceStore;
                 $newDG->tagStore->parentCentralStore = $parentDG->tagStore;
+                $newDG->scheduleStore->parentCentralStore = $parentDG->scheduleStore;
                 //Todo: swaschkut 20210505 - check if other Stores must be added
                 //- appStore;scheduleStore/securityProfileGroupStore/all kind of SecurityProfile
             }

--- a/lib/misc-classes/RQuery.php
+++ b/lib/misc-classes/RQuery.php
@@ -65,11 +65,6 @@ class RQuery
 
         $this->objectType = $objectType;
 
-        if( $this->objectType != "rule" && $this->objectType != "address" && $this->objectType != "service" && $this->objectType != "tag" && $this->objectType != "zone" && $this->objectType != "securityprofile" )
-        {
-            derr("unsupported object type '$objectType'");
-        }
-
         if( $this->objectType == 'service' )
             $this->contextObject = new ServiceRQueryContext($this);
         elseif( $this->objectType == 'address' )
@@ -82,6 +77,10 @@ class RQuery
             $this->contextObject = new ZoneRQueryContext($this);
         elseif( $this->objectType == 'securityprofile' )
             $this->contextObject = new SecurityProfileRQueryContext($this);
+        elseif( $this->objectType == 'schedule' )
+            $this->contextObject = new ScheduleRQueryContext($this);
+        else
+            derr("unsupported object type '$objectType'");
     }
 
     /**
@@ -657,5 +656,6 @@ require_once 'filters/filters-Interface.php';
 require_once 'filters/filters-Routing.php';
 require_once 'filters/filters-VirtualWire.php';
 require_once 'filters/filters-SecurityProfile.php';
+require_once 'filters/filters-Schedule.php';
 
 

--- a/lib/misc-classes/ScheduleRQueryContext.php
+++ b/lib/misc-classes/ScheduleRQueryContext.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Class ScheduleRQueryContext
+ * @property Schedule $object
+ * @ignore
+ */
+class ScheduleRQueryContext extends RQueryContext
+{
+
+}

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -345,6 +345,20 @@ RQuery::$defaultFilters['address']['name']['operators']['regex'] = array(
             $value = str_replace('$$value$$', $replace, $value);
 
         }
+        if( strpos($value, '$$ipv4$$') !== FALSE )
+        {
+            $replace = '%%%INVALID\.FOR\.THIS\.TYPE\.OF\.OBJECT%%%';
+
+            $replace = '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}';
+            $value = str_replace('$$ipv4$$', $replace, $value);
+        }
+        if( strpos($value, '$$ipv6$$') !== FALSE )
+        {
+            $replace = '%%%INVALID\.FOR\.THIS\.TYPE\.OF\.OBJECT%%%';
+
+            $replace = '[0-9a-f]{1,4}_([0-9a-f]{0,4}_){1,6}[0-9a-f]{1,4}';
+            $value = str_replace('$$ipv6$$', $replace, $value);
+        }
         if( strpos($value, '$$value.no-netmask$$') !== FALSE )
         {
             $replace = '%%%INVALID\.FOR\.THIS\.TYPE\.OF\.OBJECT%%%';

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -3051,9 +3051,9 @@ RQuery::$defaultFilters['rule']['schedule']['operators']['is'] = array(
 
         $schedule = $rule->schedule();
 
-        if( $schedule !== null )
+        if( is_object( $schedule ) )
         {
-            if( $schedule == $context->value )
+            if( $schedule->name() == $context->value )
                 return TRUE;
         }
 
@@ -3070,7 +3070,7 @@ RQuery::$defaultFilters['rule']['schedule']['operators']['is.set'] = array(
 
         $schedule = $rule->schedule();
 
-        if( $schedule !== null )
+        if( is_object( $schedule ) )
         {
             return TRUE;
         }
@@ -3088,9 +3088,9 @@ RQuery::$defaultFilters['rule']['schedule']['operators']['has.regex'] = array(
 
         $schedule = $rule->schedule();
 
-        if( $schedule !== null )
+        if( is_object( $schedule ) )
         {
-            $matching = preg_match($context->value, $schedule);
+            $matching = preg_match($context->value, $schedule->name() );
             if( $matching === FALSE )
                 derr("regular expression error on '{$context->value}'");
             if( $matching === 1 )

--- a/lib/misc-classes/filters/filters-Schedule.php
+++ b/lib/misc-classes/filters/filters-Schedule.php
@@ -1,0 +1,375 @@
+<?php
+
+// <editor-fold desc=" ***** Schedule filters *****" defaultstate="collapsed" >
+RQuery::$defaultFilters['schedule']['refcount']['operators']['>,<,=,!'] = array(
+    'eval' => '$object->countReferences() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['object']['operators']['is.unused'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        return $context->object->countReferences() == 0;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['name']['operators']['is.in.file'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $object = $context->object;
+
+        if( !isset($context->cachedList) )
+        {
+            $text = file_get_contents($context->value);
+
+            if( $text === FALSE )
+                derr("cannot open file '{$context->value}");
+
+            $lines = explode("\n", $text);
+            foreach( $lines as $line )
+            {
+                $line = trim($line);
+                if( strlen($line) == 0 )
+                    continue;
+                $list[$line] = TRUE;
+            }
+
+            $context->cachedList = &$list;
+        }
+        else
+            $list = &$context->cachedList;
+
+        return isset($list[$object->name()]);
+    },
+    'arg' => TRUE
+);
+RQuery::$defaultFilters['schedule']['object']['operators']['is.tmp'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        return $context->object->isTmp();
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['name']['operators']['eq'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        return $context->object->name() == $context->value;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% grp.shared-group1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['name']['operators']['eq.nocase'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        return strtolower($context->object->name()) == strtolower($context->value);
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% grp.shared-group1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['name']['operators']['contains'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        return strpos($context->object->name(), $context->value) !== FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% grp)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['name']['operators']['regex'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $object = $context->object;
+        $value = $context->value;
+
+        if( strlen($value) > 0 && $value[0] == '%' )
+        {
+            $value = substr($value, 1);
+            if( !isset($context->nestedQueries[$value]) )
+                derr("regular expression filter makes reference to unknown string alias '{$value}'");
+
+            $value = $context->nestedQueries[$value];
+        }
+
+        $matching = preg_match($value, $object->name());
+        if( $matching === FALSE )
+            derr("regular expression error on '{$value}'");
+        if( $matching === 1 )
+            return TRUE;
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% /-group/)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['location']['operators']['is'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $owner = $context->object->owner->owner;
+        if( strtolower($context->value) == 'shared' )
+        {
+            if( $owner->isPanorama() )
+                return TRUE;
+            if( $owner->isFirewall() )
+                return TRUE;
+            return FALSE;
+        }
+        if( strtolower($context->value) == strtolower($owner->name()) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% shared )',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['location']['operators']['regex'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $name = $context->object->getLocationString();
+        $matching = preg_match($context->value, $name);
+        if( $matching === FALSE )
+            derr("regular expression error on '{$context->value}'");
+        if( $matching === 1 )
+            return TRUE;
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% /shared/)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['location']['operators']['is.child.of'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $schedule_location = $context->object->getLocationString();
+
+        $sub = $context->object->owner;
+        while( get_class($sub) == "ScheduleStore" || get_class($sub) == "DeviceGroup" || get_class($sub) == "VirtualSystem" )
+            $sub = $sub->owner;
+
+        if( get_class($sub) == "PANConf" )
+            derr("filter location is.child.of is not working against a firewall configuration");
+
+        if( strtolower($context->value) == 'shared' )
+            return TRUE;
+
+        $DG = $sub->findDeviceGroup($context->value);
+        if( $DG == null )
+        {
+            print "ERROR: location '$context->value' was not found. Here is a list of available ones:\n";
+            print " - shared\n";
+            foreach( $sub->getDeviceGroups() as $sub1 )
+            {
+                print " - " . $sub1->name() . "\n";
+            }
+            print "\n\n";
+            exit(1);
+        }
+
+        $childDeviceGroups = $DG->childDeviceGroups(TRUE);
+
+        if( strtolower($context->value) == strtolower($schedule_location) )
+            return TRUE;
+
+        foreach( $childDeviceGroups as $childDeviceGroup )
+        {
+            if( $childDeviceGroup->name() == $schedule_location )
+                return TRUE;
+        }
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'help' => 'returns TRUE if object location (shared/device-group/vsys name) matches / is child the one specified in argument',
+    'ci' => array(
+        'fString' => '(%PROP%  Datacenter-Firewalls)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['location']['operators']['is.parent.of'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $schedule_location = $context->object->getLocationString();
+
+        $sub = $context->object->owner;
+        while( get_class($sub) == "ScheduleStore" || get_class($sub) == "DeviceGroup" || get_class($sub) == "VirtualSystem" )
+            $sub = $sub->owner;
+
+        if( get_class($sub) == "PANConf" )
+            derr("filter location is.parent.of is not working against a firewall configuration");
+
+        if( strtolower($context->value) == 'shared' )
+            return TRUE;
+
+        $DG = $sub->findDeviceGroup($context->value);
+        if( $DG == null )
+        {
+            print "ERROR: location '$context->value' was not found. Here is a list of available ones:\n";
+            print " - shared\n";
+            foreach( $sub->getDeviceGroups() as $sub1 )
+            {
+                print " - " . $sub1->name() . "\n";
+            }
+            print "\n\n";
+            exit(1);
+        }
+
+        $parentDeviceGroups = $DG->parentDeviceGroups();
+
+        if( strtolower($context->value) == strtolower($schedule_location) )
+            return TRUE;
+
+        if( $schedule_location == 'shared' )
+            return TRUE;
+
+        foreach( $parentDeviceGroups as $childDeviceGroup )
+        {
+            if( $childDeviceGroup->name() == $schedule_location )
+                return TRUE;
+        }
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'help' => 'returns TRUE if object location (shared/device-group/vsys name) matches / is parent the one specified in argument',
+    'ci' => array(
+        'fString' => '(%PROP%  Datacenter-Firewalls)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['reflocation']['operators']['is'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $object = $context->object;
+        $owner = $context->object->owner->owner;
+
+        $reflocation_array = $object->getReferencesLocation();
+
+        if( strtolower($context->value) == 'shared' )
+        {
+            if( $owner->isPanorama() )
+                return TRUE;
+            if( $owner->isFirewall() )
+                return TRUE;
+            return FALSE;
+        }
+
+        if( $owner->isPanorama() )
+        {
+            $DG = $owner->findDeviceGroup($context->value);
+            if( $DG == null )
+            {
+                $test = new UTIL("custom", array(), "");
+                $test->configType = "panorama";
+                $test->locationNotFound($context->value, null, $owner);
+            }
+        }
+
+        foreach( $reflocation_array as $reflocation )
+        {
+            #if( strtolower($reflocation) == strtolower($owner->name()) )
+            if( strtolower($reflocation) == strtolower($context->value) )
+                return TRUE;
+        }
+
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% shared )',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['reflocation']['operators']['is.only'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $owner = $context->object->owner->owner;
+        $reflocations = $context->object->getReferencesLocation();
+
+        $reftypes = $context->object->getReferencesType();
+        $refstore = $context->object->getReferencesStore();
+
+        if( strtolower($context->value) == 'shared' )
+        {
+            if( $owner->isPanorama() )
+                return TRUE;
+            if( $owner->isFirewall() )
+                return TRUE;
+            return FALSE;
+        }
+
+        $return = FALSE;
+        foreach( $reflocations as $reflocation )
+        {
+            if( strtolower($reflocation) == strtolower($context->value) )
+                $return = TRUE;
+        }
+
+        if( count($reflocations) == 1 && $return )
+            return TRUE;
+        else
+            return FALSE;
+
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% shared )',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['refstore']['operators']['is'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $value = $context->value;
+        $value = strtolower($value);
+
+        $context->object->ReferencesStoreValidation($value);
+
+        $refstore = $context->object->getReferencesStore();
+
+        if( array_key_exists($value, $refstore) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% rulestore )',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['schedule']['reftype']['operators']['is'] = array(
+    'Function' => function (ScheduleRQueryContext $context) {
+        $value = $context->value;
+        $value = strtolower($value);
+
+        $context->object->ReferencesTypeValidation($value);
+
+        $reftype = $context->object->getReferencesType();
+
+        if( array_key_exists($value, $reftype) )
+            return TRUE;
+
+        return FALSE;
+
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% securityrule )',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+
+// </editor-fold>

--- a/lib/misc-classes/trait/ObjectWithDescription.php
+++ b/lib/misc-classes/trait/ObjectWithDescription.php
@@ -80,7 +80,7 @@ trait ObjectWithDescription
         return $ret;
     }
 
-    public function description_merge(Rule $other)
+    public function description_merge( $other )
     {
         $description = $this->description();
         $other_description = $other->description();

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -605,18 +605,22 @@ class Address
 
                     if( $apiMode )
                         $newTag->API_sync();
+                }
+                if( $tag !== $newTag )
+                {
                     $tag->replaceMeGlobally($newTag);
+                    if( $apiMode )
+                    {
+                        $pickedObject->tags->API_addTag( $newTag );
+                        $tag->owner->API_removeTag($tag);
+                    }
+                    else
+                    {
+                        $pickedObject->tags->addTag( $newTag );
+                        $tag->owner->removeTag($tag);
+                    }
                 }
-                if( $apiMode )
-                {
-                    $pickedObject->tags->API_addTag( $newTag );
-                    $tag->owner->API_removeTag($tag);
-                }
-                else
-                {
-                    $pickedObject->tags->addTag( $newTag );
-                    $tag->owner->removeTag($tag);
-                }
+
             }
         }
 

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -588,6 +588,41 @@ class Address
 
     }
 
+    public function merge_tag_description_to( $pickedObject, $apiMode = false )
+    {
+        foreach( $this->tags->getAll() as $tag )
+        {
+            echo "     - merge TAG: '{$tag->name()}' before deleting...\n";
+            /** @var  Tag $tag*/
+            if( !$pickedObject->tags->hasTag( $tag ) )
+            {
+                $newTag = $pickedObject->owner->owner->tagStore->find( $tag->name() );
+                if( $newTag === null )
+                {
+                    $newTag = $pickedObject->owner->owner->tagStore->createTag( $tag->name() );
+                    $newTag->setColor( $tag->getColor() );
+                    $newTag->addComments( $tag->getComments() );
+
+                    if( $apiMode )
+                        $newTag->API_sync();
+                    $tag->replaceMeGlobally($newTag);
+                }
+                if( $apiMode )
+                {
+                    $pickedObject->tags->API_addTag( $newTag );
+                    $tag->owner->API_removeTag($tag);
+                }
+                else
+                {
+                    $pickedObject->tags->addTag( $newTag );
+                    $tag->owner->removeTag($tag);
+                }
+            }
+        }
+
+        $pickedObject->description_merge( $this );
+    }
+
     static protected $templatexml = '<entry name="**temporarynamechangeme**"><ip-netmask>tempvaluechangeme</ip-netmask></entry>';
 
 }

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -537,8 +537,9 @@ class AddressGroup
 
             return TRUE;
         }
-        else
-            mwarning("object is not part of this group: " . $old->toString());
+        elseif( !$this->isDynamic() )
+                mwarning("object is not part of this group: " . $old->toString());
+
 
 
         return FALSE;

--- a/lib/object-classes/Schedule.php
+++ b/lib/object-classes/Schedule.php
@@ -16,6 +16,12 @@ class Schedule
     /** @var TagStore|null */
     public $owner = null;
 
+    protected $_recurring = null;
+    //possible recurring setting daily/weekly/non-recurring
+
+    //daily/non-recurring could have multiple <member> XML tags
+    //weekly could have different day entried
+
 //Todo:
 //- read schedule type
 //- read members
@@ -71,11 +77,6 @@ class Schedule
         if( $fromXmlTemplate )
         {
             $doc = new DOMDocument();
-            if( $owner->owner->version < 60 )
-                derr('tag stores were introduced in v6.0');
-            else
-                $doc->loadXML(self::$templatexml, XML_PARSE_BIG_LINES);
-
             $node = DH::findFirstElement('entry', $doc);
 
             $rootDoc = $owner->xmlroot->ownerDocument;
@@ -122,7 +123,7 @@ class Schedule
      */
     public function &getXPath()
     {
-        $str = $this->owner->getTagStoreXPath() . "/entry[@name='" . $this->name . "']";
+        $str = $this->owner->getScheduleStoreXPath() . "/entry[@name='" . $this->name . "']";
 
         return $str;
     }

--- a/lib/object-classes/ScheduleStore.php
+++ b/lib/object-classes/ScheduleStore.php
@@ -8,10 +8,10 @@
  */
 
 /**
- * Class TagStore
- * @property Tag[] $o
+ * Class ScheduleStore
+ * @property Schedule[] $o
  * @property VirtualSystem|DeviceGroup|PanoramaConf|PANConf|Container|DeviceCloud $owner
- * @method Tag[] getAll()
+ * @method Schedule[] getAll()
  */
 class ScheduleStore extends ObjStore
 {
@@ -29,10 +29,10 @@ class ScheduleStore extends ObjStore
         $this->o = array();
 
         if( isset($owner->parentDeviceGroup) && $owner->parentDeviceGroup !== null )
-            $this->parentCentralStore = $owner->parentDeviceGroup->tagStore;
+            $this->parentCentralStore = $owner->parentDeviceGroup->scheduleStore;
         elseif( isset($owner->parentContainer) && $owner->parentContainer !== null )
         {
-            $this->parentCentralStore = $owner->parentContainer->tagStore;
+            $this->parentCentralStore = $owner->parentContainer->scheduleStore;
         }
         else
             $this->findParentCentralStore();
@@ -58,15 +58,15 @@ class ScheduleStore extends ObjStore
         return null;
     }
 
-    public function removeAllTags()
+    public function removeAllSchedules()
     {
         $this->removeAll();
         $this->rewriteXML();
     }
 
     /**
-     * add a Tag to this store. Use at your own risk.
-     * @param Tag $Obj
+     * add a Schedule to this store. Use at your own risk.
+     * @param Schedule $Obj
      * @param bool
      * @return bool
      */
@@ -77,7 +77,7 @@ class ScheduleStore extends ObjStore
         if( $ret && $rewriteXML )
         {
             if( $this->xmlroot === null )
-                $this->xmlroot = DH::findFirstElementOrCreate('tag', $this->owner->xmlroot);
+                $this->xmlroot = DH::findFirstElementOrCreate('schedule', $this->owner->xmlroot);
 
             $this->xmlroot->appendChild($Obj->xmlroot);
         }
@@ -91,7 +91,7 @@ class ScheduleStore extends ObjStore
      * @param integer|string $startCount
      * @return string
      */
-    public function findAvailableTagName($base, $suffix, $startCount = '')
+    public function findAvailableScheduleName($base, $suffix, $startCount = '')
     {
         $maxl = 31;
         $basel = strlen($base);
@@ -121,7 +121,7 @@ class ScheduleStore extends ObjStore
 
 
     /**
-     * return tags in this store
+     * return schedules in this store
      * @return Schedule[]
      */
     public function schedules()
@@ -132,14 +132,14 @@ class ScheduleStore extends ObjStore
     function createSchedule($name, $ref = null)
     {
         if( $this->find($name, null, FALSE) !== null )
-            derr('Tag named "' . $name . '" already exists, cannot create');
+            derr('Schedule named "' . $name . '" already exists, cannot create');
 
         if( $this->xmlroot === null )
         {
             if( $this->owner->isDeviceGroup() || $this->owner->isVirtualSystem() || $this->owner->isContainer() || $this->owner->isDeviceCloud() )
-                $this->xmlroot = DH::findFirstElementOrCreate('tag', $this->owner->xmlroot);
+                $this->xmlroot = DH::findFirstElementOrCreate('schedule', $this->owner->xmlroot);
             else
-                $this->xmlroot = DH::findFirstElementOrCreate('tag', $this->owner->sharedroot);
+                $this->xmlroot = DH::findFirstElementOrCreate('schedule', $this->owner->sharedroot);
         }
 
         $newSchedule = new Schedule($name, $this);
@@ -164,12 +164,12 @@ class ScheduleStore extends ObjStore
         if( $f !== null )
             return $f;
 
-        return $this->createTag($name, $ref);
+        return $this->createSchedule($name, $ref);
     }
 
     function API_createSchedule($name, $ref = null)
     {
-        $newSchedule = $this->createTag($name, $ref);
+        $newSchedule = $this->createSchedule($name, $ref);
 
         if( !$newSchedule->isTmp() )
         {
@@ -204,14 +204,14 @@ class ScheduleStore extends ObjStore
      * @param Schedule $schedule
      * @return bool
      */
-    public function API_removeTag(Schedule $schedule)
+    public function API_removeSchedule(Schedule $schedule)
     {
         $xpath = null;
 
         if( !$schedule->isTmp() )
             $xpath = $schedule->getXPath();
 
-        $ret = $this->removeTag($schedule);
+        $ret = $this->removeSchedule($schedule);
 
         if( $ret && !$schedule->isTmp() )
         {
@@ -233,7 +233,7 @@ class ScheduleStore extends ObjStore
         else
             derr('unsupported');
 
-        $str = $str . '/tag';
+        $str = $str . '/schedule';
 
         return $str;
     }
@@ -252,7 +252,7 @@ class ScheduleStore extends ObjStore
         return $str;
     }
 
-    public function &getTagStoreXPath()
+    public function &getScheduleStoreXPath()
     {
         $path = $this->getBaseXPath() . '/schedule';
         return $path;
@@ -297,7 +297,7 @@ class ScheduleStore extends ObjStore
         {
             $ref = $cur->owner;
             if( isset($ref->scheduleStore) &&
-                $ref->tagStore !== null )
+                $ref->scheduleStore !== null )
             {
                 $this->parentCentralStore = $ref->scheduleStore;
                 //print $this->toString()." : found a parent central store: ".$parentCentralStore->toString()."\n";
@@ -327,7 +327,7 @@ class ScheduleStore extends ObjStore
 
 
             if( isset($current->owner->owner) && $current->owner->owner !== null && !$current->owner->owner->isFawkes() )
-                $current = $current->owner->owner->tagStore;
+                $current = $current->owner->owner->scheduleStore;
             else
                 break;
         }

--- a/lib/object-classes/TagStore.php
+++ b/lib/object-classes/TagStore.php
@@ -16,7 +16,7 @@
 class TagStore extends ObjStore
 {
     /** @var null|TagStore */
-    protected $parentCentralStore = null;
+    public $parentCentralStore = null;
 
     public static $childn = 'Tag';
 

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -474,6 +474,9 @@ trait AddressCommon
 
         foreach( $this->refrules as $objectRef )
         {
+            if(  (get_class($objectRef) == "AddressGroup") && $objectRef->isDynamic() )
+                continue;
+
             if( $displayOutput )
                 echo $outputPadding . "- replacing in {$objectRef->toString()}\n";
             if( $apiMode )

--- a/lib/pan_php_framework.php
+++ b/lib/pan_php_framework.php
@@ -142,6 +142,7 @@ require_once $basedir . '/misc-classes/RuleRQueryContext.php';
 require_once $basedir . '/misc-classes/ServiceRQueryContext.php';
 require_once $basedir . '/misc-classes/TagRQueryContext.php';
 require_once $basedir . '/misc-classes/ZoneRQueryContext.php';
+require_once $basedir . '/misc-classes/ScheduleRQueryContext.php';
 
 require_once $basedir . '/misc-classes/InterfaceRQueryContext.php';
 require_once $basedir . '/misc-classes/RoutingRQueryContext.php';

--- a/tests/test_filters.php
+++ b/tests/test_filters.php
@@ -101,8 +101,10 @@ foreach( RQuery::$defaultFilters as $type => &$filtersByField )
             elseif( $type == 'zone' )
             {
                 $util = '../utils/zone-edit.php';
-                #echo "******* SKIPPED for now *******\n";
-                #continue;
+            }
+            elseif( $type == 'schedule' )
+            {
+                $util = '../utils/schedule-edit.php';
             }
             elseif( $type == 'securityprofile' )
             {

--- a/utils/common/ScheduleCallContext.php
+++ b/utils/common/ScheduleCallContext.php
@@ -1,0 +1,22 @@
+<?php
+
+class ScheduleCallContext extends CallContext
+{
+    /** @var  Schedule */
+    public $object;
+
+
+    public static $commonActionFunctions = array();
+    public static $supportedActions = array();
+
+    static public function prepareSupportedActions()
+    {
+        $tmpArgs = array();
+        foreach( self::$supportedActions as &$arg )
+        {
+            $tmpArgs[strtolower($arg['name'])] = $arg;
+        }
+        ksort($tmpArgs);
+        self::$supportedActions = $tmpArgs;
+    }
+}

--- a/utils/common/actions-schedule.php
+++ b/utils/common/actions-schedule.php
@@ -1,0 +1,366 @@
+<?php
+
+
+ScheduleCallContext::$supportedActions['delete'] = array(
+    'name' => 'delete',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+
+        if( $object->countReferences() != 0 )
+        {
+            print $context->padding . "  * SKIPPED: this object is used by other objects and cannot be deleted (use deleteForce to try anyway)\n";
+            return;
+        }
+        if( $context->isAPI )
+        {
+            # $object->owner->API_removeZone($object);
+        }
+        else
+        {
+            #$object->owner->removeZone($object);
+        }
+    },
+);
+
+ScheduleCallContext::$supportedActions['deleteforce'] = array(
+    'name' => 'deleteForce',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+
+        if( $object->countReferences() != 0 )
+            print $context->padding . "  * WARNING : this object seems to be used so deletion may fail.\n";
+        if( $context->isAPI )
+        {
+            # $object->owner->API_removeZone($object);
+        }
+        else
+        {
+            #$object->owner->removeZone($object);
+        }
+    },
+);
+
+
+ScheduleCallContext::$supportedActions['name-addprefix'] = array(
+    'name' => 'name-addPrefix',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $newName = $context->arguments['prefix'] . $object->name();
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        print $context->padding . " - new name will be '{$newName}'\n";
+        if( strlen($newName) > 127 )
+        {
+            print " *** SKIPPED : resulting name is too long\n";
+            return;
+        }
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            print " *** SKIPPED : an object with same name already exists\n";
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+
+            $object->setName($newName);
+    },
+    'args' => array('prefix' => array('type' => 'string', 'default' => '*nodefault*')
+    ),
+);
+ScheduleCallContext::$supportedActions['name-addsuffix'] = array(
+    'name' => 'name-addSuffix',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $newName = $object->name() . $context->arguments['suffix'];
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        print $context->padding . " - new name will be '{$newName}'\n";
+        if( strlen($newName) > 127 )
+        {
+            print " *** SKIPPED : resulting name is too long\n";
+            return;
+        }
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            print " *** SKIPPED : an object with same name already exists\n";
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+            $object->setName($newName);
+    },
+    'args' => array('suffix' => array('type' => 'string', 'default' => '*nodefault*')
+    ),
+);
+ScheduleCallContext::$supportedActions['name-removeprefix'] = array(
+    'name' => 'name-removePrefix',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $prefix = $context->arguments['prefix'];
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        if( strpos($object->name(), $prefix) !== 0 )
+        {
+            echo $context->padding . " *** SKIPPED : prefix not found\n";
+            return;
+        }
+        $newName = substr($object->name(), strlen($prefix));
+
+        if( !preg_match("/^[a-zA-Z0-9]/", $newName[0]) )
+        {
+            echo $context->padding . " *** SKIPPED : object name contains not allowed character at the beginning\n";
+            return;
+        }
+
+        echo $context->padding . " - new name will be '{$newName}'\n";
+
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            echo $context->padding . " *** SKIPPED : an object with same name already exists\n";
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+            $object->setName($newName);
+    },
+    'args' => array('prefix' => array('type' => 'string', 'default' => '*nodefault*')
+    ),
+);
+ScheduleCallContext::$supportedActions['name-removesuffix'] = array(
+    'name' => 'name-removeSuffix',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $suffix = $context->arguments['suffix'];
+        $suffixStartIndex = strlen($object->name()) - strlen($suffix);
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        if( substr($object->name(), $suffixStartIndex, strlen($object->name())) != $suffix )
+        {
+            echo $context->padding . " *** SKIPPED : suffix not found\n";
+            return;
+        }
+        $newName = substr($object->name(), 0, $suffixStartIndex);
+
+        echo $context->padding . " - new name will be '{$newName}'\n";
+
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            echo $context->padding . " *** SKIPPED : an object with same name already exists\n";
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+            $object->setName($newName);
+    },
+    'args' => array('suffix' => array('type' => 'string', 'default' => '*nodefault*')
+    ),
+);
+
+ScheduleCallContext::$supportedActions['name-touppercase'] = array(
+    'name' => 'name-toUpperCase',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        #$newName = $context->arguments['prefix'].$object->name();
+        $newName = mb_strtoupper($object->name(), 'UTF8');
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        print $context->padding . " - new name will be '{$newName}'\n";
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $newName === $object->name() )
+        {
+            print " *** SKIPPED : object is already uppercase\n";
+            return;
+        }
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            print " *** SKIPPED : an object with same name already exists\n";
+            #use existing uppercase TAG and replace old lowercase where used with this existing uppercase TAG
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+
+            $object->setName($newName);
+    }
+);
+ScheduleCallContext::$supportedActions['name-tolowercase'] = array(
+    'name' => 'name-toLowerCase',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        #$newName = $context->arguments['prefix'].$object->name();
+        $newName = mb_strtolower($object->name(), 'UTF8');
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        print $context->padding . " - new name will be '{$newName}'\n";
+
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $newName === $object->name() )
+        {
+            print " *** SKIPPED : object is already lowercase\n";
+            return;
+        }
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            print " *** SKIPPED : an object with same name already exists\n";
+            #use existing lowercase TAG and replace old uppercase where used with this
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+
+            $object->setName($newName);
+    }
+);
+ScheduleCallContext::$supportedActions['name-toucwords'] = array(
+    'name' => 'name-toUCWords',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        #$newName = $context->arguments['prefix'].$object->name();
+        $newName = mb_strtolower($object->name(), 'UTF8');
+        $newName = ucwords($newName);
+
+        if( $object->isTmp() )
+        {
+            echo $context->padding . " *** SKIPPED : not applicable to TMP objects\n";
+            return;
+        }
+
+        print $context->padding . " - new name will be '{$newName}'\n";
+
+        $rootObject = PH::findRootObjectOrDie($object->owner->owner);
+
+        if( $newName === $object->name() )
+        {
+            print " *** SKIPPED : object is already UCword\n";
+            return;
+        }
+
+        if( $rootObject->isPanorama() && $object->owner->find($newName, null, FALSE) !== null ||
+            $rootObject->isFirewall() && $object->owner->find($newName, null, TRUE) !== null )
+        {
+            print " *** SKIPPED : an object with same name already exists\n";
+            #use existing lowercase TAG and replace old uppercase where used with this
+            return;
+        }
+        if( $context->isAPI )
+            $object->API_setName($newName);
+        else
+
+            $object->setName($newName);
+    }
+);
+
+ScheduleCallContext::$supportedActions['displayreferences'] = array(
+    'name' => 'displayReferences',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+
+        $object->display_references(7);
+    },
+);
+
+ScheduleCallContext::$supportedActions['display'] = array(
+    'name' => 'display',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $tmp_txt = "     * " . get_class($object) . " '{$object->name()}'  ";
+
+        PH::print_stdout( $tmp_txt );
+
+
+    },
+);
+
+
+
+ScheduleCallContext::$supportedActions[] = array(
+    'name' => 'replaceWithObject',
+    'MainFunction' => function (ScheduleCallContext $context) {
+        $object = $context->object;
+        $objectRefs = $object->getReferences();
+
+        $foundObject = $object->owner->find($context->arguments['objectName']);
+
+        if( $foundObject === null )
+            derr("cannot find an object named '{$context->arguments['objectName']}'");
+
+        /** @var Zone $objectRef */
+
+        foreach( $objectRefs as $objectRef )
+        {
+            $tmp_class = get_class($objectRef);
+
+            if( $tmp_class == "ZoneRuleContainer" )
+            {
+                echo $context->padding . " * replacing in {$objectRef->toString()}\n";
+                if( $context->isAPI )
+                    $objectRef->API_replaceReferencedObject($object, $foundObject);
+                else
+                    $objectRef->replaceReferencedObject($object, $foundObject);
+            }
+            else
+            {
+                print $context->padding . "  * SKIPPED: CLASS: " . $tmp_class . " is not supported\n";
+            }
+
+
+        }
+
+    },
+    'args' => array('objectName' => array('type' => 'string', 'default' => '*nodefault*')),
+);
+

--- a/utils/common/actions.php
+++ b/utils/common/actions.php
@@ -57,3 +57,7 @@ require_once("SecurityProfileCallContext.php");
 require_once "actions-securityprofile.php";
 SecurityProfileCallContext::prepareSupportedActions();
 
+
+require_once("ScheduleCallContext.php");
+require_once "actions-schedule.php";
+ScheduleCallContext::prepareSupportedActions();

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -783,9 +783,11 @@ class MERGER extends UTIL
                                 if( $this->dupAlg == 'identical' )
                                     if( $pickedObject->name() != $ancestor->name() )
                                     {
-                                        echo "    - SKIP: object name '{$object->name()}' [with value '{$object->value()}'] is not IDENTICAL to object name from upperlevel '{$pickedObject->name()}' [with value '{$pickedObject->value()}'] \n";
+                                        echo "    - SKIP: object name '{$pickedObject->name()}' [with value '{$pickedObject->value()}'] is not IDENTICAL to object name from upperlevel '{$ancestor->name()}' [with value '{$ancestor->value()}'] \n";
                                         continue;
                                     }
+
+                                $object->merge_tag_description_to( $ancestor, $this->apiMode );
 
                                 echo "    - object '{$object->name()}' merged with its ancestor, deleting this one... ";
                                 $this->deletedObjects[$index]['kept'] = $pickedObject->name();
@@ -794,6 +796,7 @@ class MERGER extends UTIL
                                 else
                                     $this->deletedObjects[$index]['removed'] .= "|" . $object->name();
                                 $object->replaceMeGlobally($ancestor);
+
                                 if( $this->apiMode )
                                     $object->owner->API_remove($object);
                                 else
@@ -845,6 +848,8 @@ class MERGER extends UTIL
                         echo "    - replacing '{$object->_PANC_shortName()}' ...\n";
                         $object->__replaceWhereIamUsed($this->apiMode, $pickedObject, TRUE, 5);
 
+                        $object->merge_tag_description_to( $pickedObject, $this->apiMode );
+
                         echo "    - deleting '{$object->_PANC_shortName()}'\n";
                         $this->deletedObjects[$index]['kept'] = $pickedObject->name();
                         if( $this->deletedObjects[$index]['removed'] == "" )
@@ -852,13 +857,9 @@ class MERGER extends UTIL
                         else
                             $this->deletedObjects[$index]['removed'] .= "|" . $object->name();
                         if( $this->apiMode )
-                        {
                             $object->owner->API_remove($object);
-                        }
                         else
-                        {
                             $object->owner->remove($object);
-                        }
 
                         $countRemoved++;
 

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -208,6 +208,8 @@ class UTIL
             $tmp_array = &VsysCallContext::$supportedActions;
         elseif( $this->utilType == 'securityprofile' )
             $tmp_array = &SecurityProfileCallContext::$supportedActions;
+        elseif( $this->utilType == 'schedule' )
+            $tmp_array = &ScheduleCallContext::$supportedActions;
 
         return $tmp_array;
     }
@@ -289,6 +291,8 @@ class UTIL
                 VsysCallContext::prepareSupportedActions();
             elseif( $this->utilType == 'securityprofile' )
                 SecurityProfileCallContext::prepareSupportedActions();
+            elseif( $this->utilType == 'schedule' )
+                ScheduleCallContext::prepareSupportedActions();
 
             PH::print_stdout( "OK!" );
         }
@@ -747,6 +751,8 @@ class UTIL
                 $context = new VsysCallContext($tmp_array[$actionName], $explodedAction[1], $this->nestedQueries);
             elseif( $this->utilType == 'securityprofile' )
                 $context = new SecurityProfileCallContext($tmp_array[$actionName], $explodedAction[1], $this->nestedQueries);
+            elseif( $this->utilType == 'schedule' )
+                $context = new ScheduleCallContext($tmp_array[$actionName], $explodedAction[1], $this->nestedQueries);
 
             $context->baseObject = $this->pan;
             if( isset($this->configInput['type']) && $this->configInput['type'] == 'api' )
@@ -875,6 +881,8 @@ class UTIL
                         $this->objectsToProcess[] = array('store' => $this->pan->tagStore, 'objects' => $this->pan->tagStore->getall());
                     elseif( $this->utilType == 'vsys' )
                         $this->objectsToProcess[] = array('store' => $this->pan, 'objects' => $this->pan->getVirtualSystems());
+                    elseif( $this->utilType == 'schedule' )
+                        $this->objectsToProcess[] = array('store' => $this->pan->scheduleStore, 'objects' => $this->pan->scheduleStore->getall());
 
                     $locationFound = TRUE;
                 }
@@ -898,6 +906,8 @@ class UTIL
                         #$this->objectsToProcess[] = Array('store' => $sub->ruleStore, 'objects' => $sub->ruleStore->getall());
                         elseif( $this->utilType == 'tag' )
                             $this->objectsToProcess[] = array('store' => $sub->tagStore, 'objects' => $sub->tagStore->getall());
+                        elseif( $this->utilType == 'schedule' )
+                            $this->objectsToProcess[] = array('store' => $sub->scheduleStore, 'objects' => $sub->scheduleStore->getall());
                         #elseif( $this->utilType == 'vsys' )
                         #    $this->objectsToProcess[] = Array('store' => $sub->owner, 'objects' => $sub);
 
@@ -926,6 +936,8 @@ class UTIL
                     #$this->objectsToProcess[] = Array('store' => $this->pan->ruleStore, 'objects' => $this->pan->ruleStore->getall());
                     elseif( $this->utilType == 'tag' )
                         $this->objectsToProcess[] = array('store' => $this->pan->tagStore, 'objects' => $this->pan->tagStore->getall());
+                    elseif( $this->utilType == 'schedule' )
+                        $this->objectsToProcess[] = array('store' => $this->pan->scheduleStore, 'objects' => $this->pan->scheduleStore->getall());
                     elseif( $this->utilType == 'zone' )
                         $this->objectsToProcess[] = array('store' => $this->pan->zoneStore, 'objects' => $this->pan->zoneStore->getall());
 
@@ -958,7 +970,8 @@ class UTIL
                         #$this->objectsToProcess[] = Array('store' => $sub->ruleStore, 'objects' => $sub->ruleStore->getall());
                         elseif( $this->utilType == 'tag' )
                             $this->objectsToProcess[] = array('store' => $sub->tagStore, 'objects' => $sub->tagStore->getall());
-
+                        elseif( $this->utilType == 'schedule' )
+                            $this->objectsToProcess[] = array('store' => $sub->scheduleStore, 'objects' => $sub->scheduleStore->getall());
                         elseif( $this->utilType == 'zone' )
                             $this->objectsToProcess[] = array('store' => $sub->zoneStore, 'objects' => $sub->zoneStore->getall());
 

--- a/utils/schedule-edit.php
+++ b/utils/schedule-edit.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * © 2019 Palo Alto Networks, Inc.  All rights reserved.
+ *
+ * Licensed under SCRIPT SOFTWARE AGREEMENT, Palo Alto Networks, Inc., at https://www.paloaltonetworks.com/legal/script-software-license-1-0.pdf
+ *
+ */
+
+print "\n***********************************************\n";
+print   "*********** SCHEDULE-EDIT UTILITY **************\n\n";
+
+
+set_include_path(dirname(__FILE__) . '/../' . PATH_SEPARATOR . get_include_path());
+require_once dirname(__FILE__)."/../lib/pan_php_framework.php";
+
+require_once dirname(__FILE__)."/../utils/lib/UTIL.php";
+
+
+print "\n";
+
+$util = new UTIL("schedule", $argv, __FILE__);
+
+
+print "\n\n*********** END OF SCHEDULE-EDIT UTILITY **********\n";
+print     "**************************************************\n";
+print "\n\n";


### PR DESCRIPTION
## Description

UTIL | address-merger - bug fix for duplicate address with TAGS - merge also tag info
UTIL | address-edit - extend 'filter=(name regex /$$ipv4$$/)' - introduce more variables for this filter $$ipv4$$ / $$ipv6$$ - to check if address object name string includes IPv4 or IPv6 address in name
UTIL | schedule-edit - introduce this new util to first display and filter for schedule object types




