### PR TITLE
class UTIL - allow argument 'shadow-apikeynohidden' for PAN-OS <9.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ BUGFIX:
 * class customURLProfileStore | bugfix if XMLnode 'list' is not available
 
 
-2.0.4
+2.0.4 (20210519)
 UTILS:
 * pa-address/service/tag/schedule-edit introduce argument loadpanoramapushedconfig to display local and panorama pushed objects
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,7 +17,7 @@ UTILS:
 * pa-address/service/tag/schedule-edit introduce argument loadpanoramapushedconfig to display local and panorama pushed objects
 
 
-2.0.3
+2.0.3 (20210517)
 BUGFIX:
 * bugfix for pa_addressgroup-merger and pa_service-merger
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,11 @@ UTILS:
 
 BUGFIX:
 * class AddressStore - inroduce AddressGroup validation for method  nestedPointOfView()
+* UTIL | bugfix related to display_error_usage_exit usage from class UTIL
+* UTIL | class CallContext - introduce $util variable to use single ava
+* class SecurityProfileStor | bugfix for calling URLProfileStore and cu…  …
+* class customURLProfileStore | bugfix if XMLnode 'list' is not available
+
 
 2.0.4
 UTILS:

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -129,6 +129,7 @@ class UTIL
         $this->supportedArguments['expedition'] = array('niceName' => 'expedition', 'shortHelp' => 'only used if called from Expedition Tool');
         $this->supportedArguments['template'] = array('niceName' => 'template', 'shortHelp' => 'Panorama template');
         $this->supportedArguments['loadpanoramapushedconfig'] = array('niceName' => 'loadPanoramaPushedConfig', 'shortHelp' => 'load Panorama pushed config from the firewall to take in account panorama objects and rules');
+        $this->supportedArguments['shadow-apikeynohidden'] = array('niceName' => 'shadow-apikeynohidden', 'shortHelp' => 'send API-KEY in clear text via URL. this is needed for all PAN-OS version <9.0 if API mode is used. ');
     }
 
     public function utilInit()


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

UTIL script can now used with argument 'shadow-apikeynohidden' which send API-KEY via insecure way inside the URL,
this is needed for all PAN-OS version <9.0 if API mode is used