### PR TITLE
class IPsecTunnel | bugfix NOT create XML node 'proxy-id-v6' if not available

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,11 +5,12 @@ UTILS:
 * pa_rule-edit introduce 'filter=(description.length <>=! NUMBER)'
 
 BUGFIX:
-* class AddressStore - inroduce AddressGroup validation for method  nestedPointOfView()
+* class AddressStore - introduce AddressGroup validation for method  nestedPointOfView()
 * UTIL | bugfix related to display_error_usage_exit usage from class UTIL
 * UTIL | class CallContext - introduce $util variable to use single ava
 * class SecurityProfileStor | bugfix for calling URLProfileStore and cu…  …
 * class customURLProfileStore | bugfix if XMLnode 'list' is not available
+* class IPsecTunnel | bugfix NOT create XML node 'proxy-id-v6' if not avai…
 
 
 2.0.4 (20210519)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ BUGFIX:
 * class customURLProfileStore | bugfix if XMLnode 'list' is not available
 
 
-2.0.4
+2.0.4 (20210519)
 UTILS:
 * pa-address/service/tag/schedule-edit introduce argument loadpanoramapushedconfig to display local and panorama pushed objects
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,7 +17,7 @@ UTILS:
 * pa-address/service/tag/schedule-edit introduce argument loadpanoramapushedconfig to display local and panorama pushed objects
 
 
-2.0.3
+2.0.3 (20210517)
 BUGFIX:
 * bugfix for pa_addressgroup-merger and pa_service-merger
 

--- a/lib/network-classes/IPsecTunnel.php
+++ b/lib/network-classes/IPsecTunnel.php
@@ -190,7 +190,7 @@ class IPsecTunnel
                     }
                 }
                 // now extracts ProxyID for IPv6
-                $this->proxyIdRootv6 = DH::findFirstElementOrCreate('proxy-id-v6', $node);
+                $this->proxyIdRootv6 = DH::findFirstElement('proxy-id-v6', $node);
 
 
                 if( $this->proxyIdRootv6 != null )

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -129,6 +129,7 @@ class UTIL
         $this->supportedArguments['expedition'] = array('niceName' => 'expedition', 'shortHelp' => 'only used if called from Expedition Tool');
         $this->supportedArguments['template'] = array('niceName' => 'template', 'shortHelp' => 'Panorama template');
         $this->supportedArguments['loadpanoramapushedconfig'] = array('niceName' => 'loadPanoramaPushedConfig', 'shortHelp' => 'load Panorama pushed config from the firewall to take in account panorama objects and rules');
+        $this->supportedArguments['shadow-apikeynohidden'] = array('niceName' => 'shadow-apikeynohidden', 'shortHelp' => 'send API-KEY in clear text via URL. this is needed for all PAN-OS version <9.0 if API mode is used. ');
     }
 
     public function utilInit()


### PR DESCRIPTION
## Description


class IPsecTunnel | bugfix NOT create XML node 'proxy-id-v6' if not available
UTIL | class UTIL - allow argument 'shadow-apikeynohidden' for PAN-OS version <9.0 to send API-key via unsecure cleartext way