### PR TITLE
UTIL | pa_address-edit actions=replaceByMembersAndDelete - missing va…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ BUGFIX:
 * UTIL | bugfix to get argument 'apitimeout=XYZ' into working mode
 * UTIL | reinitiate class PH() at calling of UTIL()
 * UTIL | pa_rule-edit actions=exportToExcel - related to class Schedule() introduce in the past
+* UTIL | pa_address-edit actions=replaceByMembersAndDelete - missing validation if object is group
 
 2.0.4 (20210519)
 UTILS:

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -863,6 +863,18 @@ AddressCallContext::$supportedActions[] = array(
     'MainFunction' => function (AddressCallContext $context) {
         $object = $context->object;
 
+        if( !$this->isGroup() )
+        {
+            echo $context->padding . " - SKIPPED : it's not a group\n";
+            return;
+        }
+
+        if( $this->owner === null )
+        {
+            echo $context->padding . " -  SKIPPED : object was previously removed\n";
+            return;
+        }
+
         $object->replaceByMembersAndDelete($context->padding, $context->isAPI);
         /*
         if( !$object->isGroup() )


### PR DESCRIPTION
…lidation if object is group

## Description

UTIL | pa_address-edit actions=replaceByMembersAndDelete - missing validation if object is group
