### PR TITLE
class EthernetInterface | setLinkState not possible for subinterfaces

### DIFF
--- a/lib/network-classes/EthernetInterface.php
+++ b/lib/network-classes/EthernetInterface.php
@@ -747,6 +747,9 @@ class EthernetInterface
      */
     public function setLinkState($linkstate)
     {
+        if( $this->isSubInterface() )
+            return false;
+        
         $linkstate_array = array( "auto","up", "down" );
         if( !in_array( $linkstate, $linkstate_array) )
             return false;


### PR DESCRIPTION
## Description


