### PR TITLE
UTIL pa_upload-config | bugfix in=api://MGMT-IP/merged-config - bringing this feature back to specify tto download running-/merged-/candidate-config

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,8 @@ CHANGELOG
 UTILS:
 
 BUGFIX:
-* pa_upload-config in=api://MGMT-IP/merged-config - bringing this feature back to specify tto download running-/merged-/candidate-config
+* pa_upload-config in=api://MGMT-IP/merged-config - bringing this feature back to specify to download running-/merged-/candidate-config
+* framework class ObjStore - bugfix - extend validation about existing variable setting
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTILS:
 
 BUGFIX:
+* pa_upload-config in=api://MGMT-IP/merged-config - bringing this feature back to specify tto download running-/merged-/candidate-config
 
 GENERAL:
 

--- a/lib/object-classes/ObjStore.php
+++ b/lib/object-classes/ObjStore.php
@@ -81,7 +81,7 @@ class ObjStore
         if( get_class( $this ) == "EthernetIfStore" || get_class( $this ) == "AggregateEthernetIfStore" || get_class( $this ) == "VirtuelWireStore" )
             return null;
 
-        if( $nested && $this->parentCentralStore !== null )
+        if( $nested && isset($this->parentCentralStore) && $this->parentCentralStore !== null )
         {
             $f = $this->parentCentralStore->findbyName($name, $ref, $nested);
             if( $f !== null )

--- a/lib/rule-classes/Rule.php
+++ b/lib/rule-classes/Rule.php
@@ -895,7 +895,7 @@ class Rule
 
                 PH::print_stdout( $padding . " - VSYS/DG '{$system->name()}' has interfaces attached to " . count($foundRouters) . " virtual routers" );
                 if( count($foundRouters) > 1 )
-                    derr("more than 1 suitable virtual routers found, please specify one fo the following: " . PH::list_to_string($foundRouters));
+                    derr("more than 1 suitable virtual routers found, please specify one of the following: " . PH::list_to_string($foundRouters));
                 if( count($foundRouters) == 0 )
                     derr("no suitable VirtualRouter found, please force one or check your configuration");
 

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -753,16 +753,16 @@ class UTIL
             PH::print_stdout( " - Downloading config from API... " );
 
 
-            if( !isset($configInput['filename']) || $configInput['filename'] == '' || $configInput['filename'] == 'candidate-config' )
+            if( !isset($this->configInput['filename']) || $this->configInput['filename'] == '' || $this->configInput['filename'] == 'candidate-config' )
                 $this->xmlDoc = $this->configInput['connector']->getCandidateConfig( $this->apiTimeoutValue );
-            elseif( $configInput['filename'] == 'running-config' )
+            elseif( $this->configInput['filename'] == 'running-config' )
                 $this->xmlDoc = $this->configInput['connector']->getRunningConfig();
-            elseif( $configInput['filename'] == 'merged-config' || $configInput['filename'] == 'merged' )
+            elseif( $this->configInput['filename'] == 'merged-config' || $this->configInput['filename'] == 'merged' )
                 $this->xmlDoc = $this->configInput['connector']->getMergedConfig();
-            elseif( $configInput['filename'] == 'panorama-pushed-config' || $configInput['filename'] == 'panorama-pushed' )
+            elseif( $this->configInput['filename'] == 'panorama-pushed-config' || $this->configInput['filename'] == 'panorama-pushed' )
                 $this->xmlDoc = $this->configInput['connector']->getPanoramaPushedConfig();
             else
-                $this->xmlDoc = $this->configInput['connector']->getSavedConfig($configInput['filename']);
+                $this->xmlDoc = $this->configInput['connector']->getSavedConfig($this->configInput['filename']);
 
         }
         else


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- UTIL pa_upload-config | bugfix in=api://MGMT-IP/merged-config - bringing this feature back to specify to download running-/merged-/candidate-config
- framework class ObjStore - bugfix - extend validation about existing variable setting