### PR TITLE
UTIL pa_tag-edit | actions=created:NewTag - bugfix to not error out o…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTILS:
 
 BUGFIX:
 * UTIL script download predefined PAN-OS content data - bugfix/workaround if PAN-OS API bring in double <response><return
+* pa_tag-edit | actions=created:NewTag - bugfix to not error out on PAN-OS API - first check if NewTag is already availalble
 
 GENERAL:
 * framework - content id update to version 8494-7079

--- a/utils/common/actions-tag.php
+++ b/utils/common/actions-tag.php
@@ -721,13 +721,23 @@ TagCallContext::$supportedActions['create'] = array(
 
         $newName = $context->arguments['name'];
 
-        $string = "create Tag object : '" . $newName . "'";
-        PH::ACTIONlog( $context, $string );
 
-        if( $context->isAPI )
-            $tagStore->API_createTag($newName);
+        if( $tagStore->find( $newName ) === null )
+        {
+            $string = "create Tag object : '" . $newName . "'";
+            PH::ACTIONlog( $context, $string );
+
+            if( $context->isAPI )
+                $tagStore->API_createTag($newName);
+            else
+                $tagStore->createTag($newName);
+        }
         else
-            $tagStore->createTag($newName);
+        {
+            $string = "Tag named '" . $newName . "' lready exists, cannot create";
+            PH::ACTIONlog( $context, $string );
+        }
+
     },
     'args' => array('name' => array('type' => 'string', 'default' => '*nodefault*')
     )


### PR DESCRIPTION
…n PAN-OS API - first check if NewTag is already availalble

## Description
