### PR TITLE
UTIL pan-os-php type=xml-issue | introduce new check if address/-grou…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ UTILS:
 * UTIL all script argument 'outputformatset' | improve display set commands
 * UTIL develop | introduce new script - display-xpath-value  - display-xpath-for-node-filter
 * UTIL UI | per-default always set shadow-ignoreinvalidaddressobjects
+* UTIL pan-os-php type=xml-issue | introduce new check if address/-group/service/-group/secRule/natRule objectname has double spaces in it
 
 BUGFIX:
 * UTIL UI - still in BETA - bugfix to create correct JSON playbook file if location argument is used

--- a/git-php/composer.json
+++ b/git-php/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6.0"
+		"php": ">=7.3"
 	},
 	"autoload": {
 		"classmap": ["src/"]


### PR DESCRIPTION
…p/service/-group/secRule/natRule objectname has double spaces in it

double spaces causes problems during copy&past of set commands into PAN-OS CLI

## Description

<!--- Describe your changes in detail -->
