### PR TITLE
UTIL type=securityprofile actions=custom-url-category-add-ending-token - improvement avoid adding token if '*' is already available at end of string

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ UTILS:
 * UTIL pan-os-php type=service | actions=name-rename:$$timeout$$ - introduce VARIABLE $$timeout$$
 * UTIL  argument 'outputformatset' - correction of 'set commands' order print
 * UTIL develop/ssh_connector.php | introduce argument 'setcommandfile=FILE' for quick validation check of create "set commands"
+* UTIL type=securityprofile actions=custom-url-category-add-ending-token - improvement avoid adding token if '*' is already available at end of string
 
 BUGFIX:
 * UTIL UI - still in BETA - bugfix to create correct JSON playbook file if location argument is used

--- a/lib/misc-classes/DH.php
+++ b/lib/misc-classes/DH.php
@@ -546,6 +546,10 @@ class DH
 
         $xpath = $type . $fullpath;
 
+
+        if( strpos( $xpath, " member" ) !== FALSE )
+            $xpath = str_replace( " member", "", $xpath );
+
         //print "XPATH:|".$xpath."|\n";
 
         if( $element->nodeType == XML_ELEMENT_NODE ) //1
@@ -577,9 +581,11 @@ class DH
             }
             else
             {
-                //print "XPATH:|".$xpath."|\n";
-                //print $element->nodeName."\n";
-                //print "STRING1:|".$string."|\n";
+                /*
+                print "XPATH:|".$xpath."|\n";
+                print $element->nodeName."\n";
+                print "STRING1:|".$string."|\n";
+                */
                 if( strpos( $xpath, " ".$element->nodeName ) === FALSE )
                 {
                     if( $element->nodeName !== "member" )

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -214,7 +214,7 @@ class AddressGroup
 
                     if( isset($membersIndex[$memberName]) )
                     {
-                        mwarning("duplicated member named '{$memberName}' detected in address group '{$this->name}',  you should review your XML config file", $this->xmlroot);
+                        mwarning("duplicated member named '{$memberName}' detected in addressgroup '{$this->name}',  you should review your XML config file", $this->xmlroot, false);
                         continue;
                     }
                     $membersIndex[$memberName] = TRUE;
@@ -772,7 +772,7 @@ class AddressGroup
             {
                 if( $this->name() == $object->name() )
                 {
-                    mwarning("addressgroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file");
+                    mwarning("addressgroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
                     continue;
                 }
 

--- a/lib/object-classes/ServiceGroup.php
+++ b/lib/object-classes/ServiceGroup.php
@@ -111,7 +111,7 @@ class ServiceGroup
                 foreach( $this->members as $member )
                     if( $member === $f )
                     {
-                        mwarning("service '{$memberName}' is already part of group '{$this->name}', you should review your config file");
+                        mwarning("duplicated member named '{$memberName}' detected in servicegroup '{$this->name}', you should review your XML config file", $this->xmlroot, false);
                         $alreadyInGroup = TRUE;
                         break;
                     }
@@ -138,7 +138,7 @@ class ServiceGroup
                 foreach( $this->members as $member )
                     if( $member === $f )
                     {
-                        mwarning("duplicated member named '{$memberName}' detected in service group '{$this->name}', you should review your XML config file", $this->xmlroot);
+                        mwarning("duplicated member named '{$memberName}' detected in servicegroup '{$this->name}', you should review your XML config file", $this->xmlroot, false);
                         $alreadyInGroup = TRUE;
                         break;
                     }
@@ -626,7 +626,7 @@ class ServiceGroup
             {
                 if( $this->name() == $object->name() )
                 {
-                    mwarning("servicegroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file");
+                    mwarning("servicegroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
                     continue;
                 }
 

--- a/utils/common/actions-securityprofile.php
+++ b/utils/common/actions-securityprofile.php
@@ -597,9 +597,13 @@ SecurityProfileCallContext::$supportedActions['custom-url-category-add-ending-to
             PH::print_stdout(  "        - " . $member );
             PH::$JSON_TMP['sub']['object'][$object->name()]['members'][] = $member;
 
+            $skiptokenArray = array( '*' );
+
             $lastChar = substr($member, -1);
             if( in_array( $lastChar, $tokenArray ) )
                 PH::print_stdout(  "skipped! endingToken already available: '".$lastChar."'" );
+            elseif( in_array( $lastChar, $skiptokenArray ) )
+                PH::print_stdout(  "skipped! following token available at lastChar: '".$lastChar."'" );
             else
             {
                 $object->addMember( $member.$newToken );


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

[UTIL argument 'outputformatset' | another bugfix to remove XMLnodeName 'member' in fullXpath