### PR TITLE
UTIL type=rule | actions=exportToExcel - extend with service Counter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ CHANGELOG
 
 2.0.32
 UTILS:
+* UTIL type=rule | rework 'filter=(service port.counter)' is now 'filter=(service.port.count >,<,=,! COUNT)')
+* UTIL type=rule | extend actions=exportToExcel with service Counter
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,13 @@
 CHANGELOG
 
+2.0.32
+UTILS:
+
+BUGFIX:
+
+GENERAL:
+
+
 2.0.31 (20220303)
 UTILS:
 * pan-os-php type=xml-issue | extend fix for custom-url-category

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -153,7 +153,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 0;
-    private static $library_version_bugfix = 31;
+    private static $library_version_bugfix = 32;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/RuleRQueryContext.php
+++ b/lib/misc-classes/RuleRQueryContext.php
@@ -7,5 +7,32 @@
  */
 class RuleRQueryContext extends RQueryContext
 {
+    public function ServiceCount( $rule, $type = "both" )
+    {
+        $objects = $rule->services->o;
 
+        if( count($objects  ) > 0 )
+        {
+            $dst_port_mapping = new ServiceDstPortMapping();
+            $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
+
+            $dst_port_mapping->countPortmapping();
+            if( $type === "both" )
+                $calculatedCounter = $dst_port_mapping->PortCounter;
+            elseif( $type === "tcp" )
+                $calculatedCounter = $dst_port_mapping->tcpPortCounter;
+            elseif( $type === "udp" )
+                $calculatedCounter = $dst_port_mapping->udpPortCounter;
+        }
+        else
+        {
+            $maxPortcount = 65536;
+            if( $type === "both" )
+                $calculatedCounter = ($maxPortcount * 2);
+            elseif( $type === "tcp" || $type === "udp" )
+                $calculatedCounter = $maxPortcount;
+        }
+
+        return $calculatedCounter;
+    }
 }

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -1615,7 +1615,7 @@ RQuery::$defaultFilters['rule']['service']['operators']['has.value.only'] = arra
     )
 );
 
-RQuery::$defaultFilters['rule']['service']['operators']['port.counter.greater.than'] = array(
+RQuery::$defaultFilters['rule']['service.port.count']['operators']['>,<,=,!'] = array(
     'Function' => function (RuleRQueryContext $context) {
         $counter = $context->value;
         $rule = $context->object;
@@ -1626,14 +1626,11 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.counter.greater.th
             return FALSE;
         }
 
-        $objects = $rule->services->o;
+        $calculatedCounter = $context->ServiceCount( $rule, "both");
 
-        $dst_port_mapping = new ServiceDstPortMapping();
-        $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
-
-        $dst_port_mapping->countPortmapping();
-
-        if( $dst_port_mapping->PortCounter > $counter )
+        $operator = $context->operator;
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
             return TRUE;
 
         return FALSE;
@@ -1644,8 +1641,7 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.counter.greater.th
         'input' => 'input/panorama-8.0.xml'
     )
 );
-
-RQuery::$defaultFilters['rule']['service']['operators']['port.tcp.counter.greater.than'] = array(
+RQuery::$defaultFilters['rule']['service.port.tcp.count']['operators']['>,<,=,!'] = array(
     'Function' => function (RuleRQueryContext $context) {
         $counter = $context->value;
         $rule = $context->object;
@@ -1656,14 +1652,11 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.tcp.counter.greate
             return FALSE;
         }
 
-        $objects = $rule->services->o;
+        $calculatedCounter = $context->ServiceCount( $rule, "tcp");
 
-        $dst_port_mapping = new ServiceDstPortMapping();
-        $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
-
-        $dst_port_mapping->countPortmapping();
-
-        if( $dst_port_mapping->tcpPortCounter > $counter )
+        $operator = $context->operator;
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
             return TRUE;
 
         return FALSE;
@@ -1674,8 +1667,7 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.tcp.counter.greate
         'input' => 'input/panorama-8.0.xml'
     )
 );
-
-RQuery::$defaultFilters['rule']['service']['operators']['port.udp.counter.greater.than'] = array(
+RQuery::$defaultFilters['rule']['service.port.udp.count']['operators']['>,<,=,!'] = array(
     'Function' => function (RuleRQueryContext $context) {
         $counter = $context->value;
         $rule = $context->object;
@@ -1686,14 +1678,11 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.udp.counter.greate
             return FALSE;
         }
 
-        $objects = $rule->services->o;
+        $calculatedCounter = $context->ServiceCount( $rule, "udp");
 
-        $dst_port_mapping = new ServiceDstPortMapping();
-        $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
-
-        $dst_port_mapping->countPortmapping();
-
-        if( $dst_port_mapping->udpPortCounter > $counter )
+        $operator = $context->operator;
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
             return TRUE;
 
         return FALSE;
@@ -1704,6 +1693,7 @@ RQuery::$defaultFilters['rule']['service']['operators']['port.udp.counter.greate
         'input' => 'input/panorama-8.0.xml'
     )
 );
+//
 //                                              //
 //                SecurityProfile properties    //
 //                                              //

--- a/utils/common/RuleCallContext.php
+++ b/utils/common/RuleCallContext.php
@@ -360,6 +360,24 @@ class RuleCallContext extends CallContext
             return self::enclose($port_mapping_text);
         }
 
+        if( $fieldName == 'service_count' )
+        {
+            $calculatedCounter = self::ServiceCount( $rule, "both" );
+            return self::enclose((string)$calculatedCounter);
+        }
+
+        if( $fieldName == 'service_count_tcp' )
+        {
+            $calculatedCounter = self::ServiceCount( $rule, "tcp" );
+            return self::enclose((string)$calculatedCounter);
+        }
+
+        if( $fieldName == 'service_count_udp' )
+        {
+            $calculatedCounter = self::ServiceCount( $rule, "udp" );
+            return self::enclose((string)$calculatedCounter);
+        }
+
         if( $fieldName == 'application' )
         {
             if( !$rule->isSecurityRule() )
@@ -661,6 +679,35 @@ class RuleCallContext extends CallContext
         }
 
         return $port_mapping_text;
+    }
+
+    public function ServiceCount( $rule, $type = "both" )
+    {
+        $objects = $rule->services->o;
+
+        if( count($objects  ) > 0 )
+        {
+            $dst_port_mapping = new ServiceDstPortMapping();
+            $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
+
+            $dst_port_mapping->countPortmapping();
+            if( $type === "both" )
+                $calculatedCounter = $dst_port_mapping->PortCounter;
+            elseif( $type === "tcp" )
+                $calculatedCounter = $dst_port_mapping->tcpPortCounter;
+            elseif( $type === "udp" )
+                $calculatedCounter = $dst_port_mapping->udpPortCounter;
+        }
+        else
+        {
+            $maxPortcount = 65536;
+            if( $type === "both" )
+                $calculatedCounter = ($maxPortcount * 2);
+            elseif( $type === "tcp" || $type === "udp" )
+                $calculatedCounter = $maxPortcount;
+        }
+
+        return $calculatedCounter;
     }
 
     public function ApplicationResolveSummary( $rule, $returnString = false )

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -3128,6 +3128,10 @@ RuleCallContext::$supportedActions[] = array(
             {
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_resolved_sum'] = $context->ServiceResolveSummary( $rule );
             }
+            PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_count'] = $context->ServiceCount( $rule, "both" );
+            PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_count_tcp'] = $context->ServiceCount( $rule, "tcp" );
+            PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_count_udp'] = $context->ServiceCount( $rule, "udp" );
+
             if( $addResolvedApplicationSummary )
             {
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['app_resolved_sum'] = $context->ApplicationResolveSummary( $rule );
@@ -3542,6 +3546,9 @@ RuleCallContext::$supportedActions[] = array(
             'dst_resolved_sum' => 'dst_resolved_sum',
             'service' => 'service',
             'service_resolved_sum' => 'service_resolved_sum',
+            'service_count' => 'service_count',
+            'service_count_tcp' => 'service_count_tcp',
+            'service_count_udp' => 'service_count_udp',
             'application' => 'application',
             'application_resolved_sum' => 'application_resolved_sum',
             'action' => 'action',


### PR DESCRIPTION
## Description

- actions=exportToExcel:file.html

- 'filter=(service.port.count > PORTCOUNT)'

renaming of rule filter, which were just introduced last week, to fit into general count filters:

'filter=(service.port.count > PORTCOUNT)'
'filter=(service.port.tcp.count > PORTCOUNT)'
'filter=(service.port.udp.count > PORTCOUNT)'

as operators the following can be used;
'>,<,=,!'