### PR TITLE
UTIL type=address/service actions=move:XYZ,removeifmatch | bugfix if nested group has different group members

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ BUGFIX:
 * class IP4MAP | bugfix for all filters where IP calculation is used e.g. UTIL type=rule 'filter=(src is.partially.or.fully.included.in.list LIST)'
 * class SecurityProfileGroupStrore | bugfix to search for available object name only in current Store
 * UTIL type=address actions=move:XYZ,removeifmatch | bugfix if address-group has same nested address-group member, but this nested group has different members
+* UTIL type=service actions=move:XYZ,removeifmatch | bugfix for nested servicegroups with different members
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ BUGFIX:
 * UTIL type=rule | actions=exportToExcel - bugfix for service.count if application-default is set
 * UTIL type=rule | 'filter=(service.port.count = PORTCOUNT)' - bugfix to change in code to '=='
 * class IP4MAP | bugfix for all filters where IP calculation is used e.g. UTIL type=rule 'filter=(src is.partially.or.fully.included.in.list LIST)'
+* class SecurityProfileGroupStrore | bugfix to search for available object name only in current Store
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ BUGFIX:
 * UTIL type=rule | 'filter=(service.port.count = PORTCOUNT)' - bugfix to change in code to '=='
 * class IP4MAP | bugfix for all filters where IP calculation is used e.g. UTIL type=rule 'filter=(src is.partially.or.fully.included.in.list LIST)'
 * class SecurityProfileGroupStrore | bugfix to search for available object name only in current Store
+* UTIL type=address actions=move:XYZ,removeifmatch | bugfix if address-group has same nested address-group member, but this nested group has different members
 
 GENERAL:
 

--- a/lib/object-classes/SecurityProfileGroupStore.php
+++ b/lib/object-classes/SecurityProfileGroupStore.php
@@ -226,7 +226,7 @@ class SecurityProfileGroupStore extends ObjStore
             else
                 $newname = $base . $suffix . $inc;
 
-            if( $this->find($newname) === null )
+            if( $this->find($newname, null, FALSE) === null )
                 return $newname;
 
             if( $startCount == '' )

--- a/lib/object-classes/SecurityProfileStore.php
+++ b/lib/object-classes/SecurityProfileStore.php
@@ -216,6 +216,7 @@ class SecurityProfileStore extends ObjStore
             return $foundObject;
         }*/
 
+        /*
         // when load a PANOS firewall attached to a Panorama
         if( $nested && isset($this->panoramaShared) )
         {
@@ -231,6 +232,7 @@ class SecurityProfileStore extends ObjStore
             if( $f !== null )
                 return $f;
         }
+        */
 
         if( $nested && $this->parentCentralStore !== null )
         {

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1464,8 +1464,15 @@ AddressCallContext::$supportedActions[] = array(
 
         if( $object->isGroup() )
         {
-            if( $object->equals($conflictObject) )
+            $localMap = $object->getIP4Mapping();
+            $targetMap = $conflictObject->getIP4Mapping();
+
+            if( $object->equals($conflictObject) && $localMap->equals($targetMap) )
+            //if( $object->equals($conflictObject) )
             {
+                //
+                //bug; deep matching ip4mapping needed
+
                 $string = "Removed because target has same content";
                 PH::ACTIONlog( $context, $string );
 
@@ -1486,9 +1493,6 @@ AddressCallContext::$supportedActions[] = array(
                     PH::ACTIONstatus( $context, "SKIPPED", $string );
                     return;
                 }
-
-                $localMap = $object->getIP4Mapping();
-                $targetMap = $conflictObject->getIP4Mapping();
 
                 if( !$localMap->equals($targetMap) )
                 {

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -581,7 +581,10 @@ ServiceCallContext::$supportedActions[] = array(
 
         if( $object->isGroup() )
         {
-            if( $object->equals($conflictObject) )
+            $localMap = $object->dstPortMapping();
+            $targetMap = $conflictObject->dstPortMapping();
+
+            if( $object->equals($conflictObject) && $localMap->equals($targetMap) )
             {
                 $string = "Removed because target has same content";
                 PH::ACTIONlog( $context, $string );
@@ -597,9 +600,6 @@ ServiceCallContext::$supportedActions[] = array(
                     PH::ACTIONstatus( $context, "SKIPPED", $string );
                     return;
                 }
-
-                $localMap = $object->dstPortMapping();
-                $targetMap = $conflictObject->dstPortMapping();
 
                 if( !$localMap->equals($targetMap) )
                 {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

bug fix description:
if you like to move a group (GRP1), which has another group included as member (GRP2),
and this GRP2 has different members on DG child, compare to your target DG.
