### PR TITLE
class PanAPIConnector | bugfix to avoid using shadow-apikeynohidden for PAN-OS >=9 if Panorama is used as proxy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTILS:
 BUGFIX:
 * UTIL API - bugfix related to JSON output
 * UTIL type=rule | bugfix 'filter=(rule is.unused.fast)' if searching via API mode on Panorama
+* class PanAPIConnector | bugfix to avoid using shadow-apikeynohidden for PAN-OS >=9 if Panorama is used as proxy
 
 GENERAL:
 

--- a/lib/misc-classes/PanAPIConnector.php
+++ b/lib/misc-classes/PanAPIConnector.php
@@ -1089,7 +1089,6 @@ class PanAPIConnector
                     $finalUrl .= '?key=' . urlencode($this->apikey) . '&target=' . $this->serial;
                 else
                 {
-                    //Todo: possible improvements for API security with PAN-OS 9.0 [20181030]
                     $finalUrl .= '?target=' . $this->serial;
                     curl_setopt($this->_curl_handle, CURLOPT_HTTPHEADER, array('X-PAN-KEY: ' . $this->apikey));
                 }
@@ -1107,26 +1106,15 @@ class PanAPIConnector
                     $finalUrl .= '?key=' . urlencode($this->apikey);
                 else
                 {
-                    //Todo: possible improvements for API security with PAN-OS 9.0 [20181030]
                     $finalUrl .= '?';
                     curl_setopt($this->_curl_handle, CURLOPT_HTTPHEADER, array('X-PAN-KEY: ' . $this->apikey));
                 }
-
             }
-
         }
 
         if( !$sendThroughPost )
-        {
-            #print_r( $parameters );
-            //$url = str_replace('#', '%23', $parameters);
-            if( !PH::$sendAPIkeyviaHeader )
-                $finalUrl .= '&' . $parameters;
-            else
-            {
-                $finalUrl .= $parameters;
-            }
-        }
+            $finalUrl .= '&' . $parameters;
+
 
         curl_setopt($this->_curl_handle, CURLOPT_URL, $finalUrl);
 


### PR DESCRIPTION


## Description

<!--- Describe your changes in detail -->
