### PR TITLE
framework harding and bugfixes - version 2.0.36

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ BUGFIX:
 * class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
 * UTIL type=rule | bugfix for actions=from-Set-Any / actions=src-dst-swap
 * UTIL type=address | bugfix related to custom Region object - class Region()
+* class AddressGroup | bugfix for dynamic AddressGroup - do not add own Group if tagged as member
 
 GENERAL:
 * framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.0.36
 UTILS:
 * UTIL type=device | introduce idle time for actions=system-admin-session
+* UTIL type=device | actions=system-admin-session:delete,8
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@ UTILS:
 BUGFIX:
 
 GENERAL:
+* framework | all API request are now send via GET, POST method is no longer supported with PAN-OS 10.2
+* framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0
 
 
 2.0.35 (20220411)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTILS:
 * UTIL type=service-merger | extend output with protocol
 * UTIL type=ALLOBJECTMERGER script | shadow-json and exportcsv argument will now also store HTML file locally
 * class Tag | improve method setColor() - to successfully read SASE API config response
+* UTIL type=service | delete deprecated actions=deleteForce - use actions=delete-Force
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTILS:
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object
 * class UTIL | bugfix for Fawkes config type related to timezone setting
+* class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
 
 GENERAL:
 * framework | all API request are now send via GET, POST method is no longer supported with PAN-OS 10.2

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTILS:
 * UTIL type=device | actions=system-admin-session:delete,8
 
 BUGFIX:
+* CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object
 
 GENERAL:
 * framework | all API request are now send via GET, POST method is no longer supported with PAN-OS 10.2

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTILS:
 * UTIL type=device | introduce idle time for actions=system-admin-session
 * UTIL type=device | actions=system-admin-session:delete,8
+* UTIL type=service-merger | extend output with protocol
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,13 @@
 CHANGELOG
 
+2.0.36
+UTILS:
+
+BUGFIX:
+
+GENERAL:
+
+
 2.0.35 (20220411)
 UTILS:
 * UTIL type=device | introduce actions=system-restart / system-mgt-config_users /  system-admin-session:display / system-admin-session:delete,1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ BUGFIX:
 * class UTIL | bugfix for Fawkes config type related to timezone setting
 * class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
 * UTIL type=rule | bugfix for actions=from-Set-Any / actions=src-dst-swap
+* UTIL type=address | bugfix related to custom Region object - class Region()
 
 GENERAL:
 * framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTILS:
 * UTIL type=device | actions=system-admin-session:delete,8
 * UTIL type=service-merger | extend output with protocol
 * UTIL type=ALLOBJECTMERGER script | shadow-json and exportcsv argument will now also store HTML file locally
+* class Tag | improve method setColor() - to successfully read SASE API config response
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object
 * class UTIL | bugfix for Fawkes config type related to timezone setting
 * class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
+* UTIL type=rule | bugfix for actions=from-Set-Any / actions=src-dst-swap
 
 GENERAL:
 * framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTILS:
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object
+* class UTIL | bugfix for Fawkes config type related to timezone setting
 
 GENERAL:
 * framework | all API request are now send via GET, POST method is no longer supported with PAN-OS 10.2

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ BUGFIX:
 
 GENERAL:
 * framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0
+* framework | extend test_actions and test_filers
 
 
 2.0.35 (20220411)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.0.36
 UTILS:
+* UTIL type=device | introduce idle time for actions=system-admin-session
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTILS:
 * UTIL type=ALLOBJECTMERGER script | shadow-json and exportcsv argument will now also store HTML file locally
 * class Tag | improve method setColor() - to successfully read SASE API config response
 * UTIL type=service | delete deprecated actions=deleteForce - use actions=delete-Force
+* class SecurityRule - introduce rewriteSchedule_XML() - use it in new method referencedObjectRenamed()
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTILS:
 * UTIL type=device | introduce idle time for actions=system-admin-session
 * UTIL type=device | actions=system-admin-session:delete,8
 * UTIL type=service-merger | extend output with protocol
+* UTIL type=ALLOBJECTMERGER script | shadow-json and exportcsv argument will now also store HTML file locally
 
 BUGFIX:
 * CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,7 +13,6 @@ BUGFIX:
 * class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
 
 GENERAL:
-* framework | all API request are now send via GET, POST method is no longer supported with PAN-OS 10.2
 * framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0
 
 

--- a/lib/container-classes/AddressRuleContainer.php
+++ b/lib/container-classes/AddressRuleContainer.php
@@ -317,6 +317,9 @@ class AddressRuleContainer extends ObjRuleContainer
 
         foreach( $this->o as $o )
         {
+            if( $o->isRegion() )
+                continue;
+
             $localResult = $o->includedInIP4Network($netStartEnd);
             if( $localResult == 1 )
             {

--- a/lib/container-classes/AddressRuleContainer.php
+++ b/lib/container-classes/AddressRuleContainer.php
@@ -365,6 +365,9 @@ class AddressRuleContainer extends ObjRuleContainer
 
         foreach( $this->o as $o )
         {
+            if( $o->isRegion() )
+                continue;
+
             $localResult = $o->includesIP4Network($netStartEnd);
             if( $localResult == 1 )
             {

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -134,7 +134,7 @@ class PH
     public static $ignoreInvalidAddressObjects = FALSE;
 
     /** @var bool set to true if you want to send API key via HEADER - possible starting with PAN-OS 9.0 */
-    public static $sendAPIkeyviaHeader = TRUE;
+    public static $sendAPIkeyviaHeader = FALSE;
 
     public static $saveAPIkey = TRUE;
 

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -153,7 +153,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 0;
-    private static $library_version_bugfix = 35;
+    private static $library_version_bugfix = 36;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/PanAPIConnector.php
+++ b/lib/misc-classes/PanAPIConnector.php
@@ -1061,8 +1061,15 @@ class PanAPIConnector
     {
         $sendThroughPost = FALSE;
 
+        $tmp_parameters = "";
         if( is_array($parameters) )
-            $sendThroughPost = TRUE;
+        {
+            foreach( $parameters as $key => $parameter )
+                $tmp_parameters .= "&".$key."=".$parameter;
+            $parameters = substr($tmp_parameters, 1);
+            #$sendThroughPost = TRUE;
+        }
+
 
         $this->_createOrRenewCurl();
 

--- a/lib/misc-classes/PanAPIConnector.php
+++ b/lib/misc-classes/PanAPIConnector.php
@@ -1061,14 +1061,8 @@ class PanAPIConnector
     {
         $sendThroughPost = FALSE;
 
-        $tmp_parameters = "";
         if( is_array($parameters) )
-        {
-            foreach( $parameters as $key => $parameter )
-                $tmp_parameters .= "&".$key."=".$parameter;
-            $parameters = substr($tmp_parameters, 1);
-            #$sendThroughPost = TRUE;
-        }
+            $sendThroughPost = TRUE;
 
 
         $this->_createOrRenewCurl();

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -107,7 +107,7 @@ RQuery::$defaultFilters['rule']['to']['operators']['has.regex'] = array(
 );
 
 RQuery::$defaultFilters['rule']['from.count']['operators']['>,<,=,!'] = array(
-    'eval' => "\$object->from->count() !operator! !value!",
+    'eval' => "!\$object->isPbfRule() && \$object->from->count() !operator! !value!",
     'arg' => TRUE,
     'ci' => array(
         'fString' => '(%PROP% 1)',
@@ -115,7 +115,7 @@ RQuery::$defaultFilters['rule']['from.count']['operators']['>,<,=,!'] = array(
     )
 );
 RQuery::$defaultFilters['rule']['to.count']['operators']['>,<,=,!'] = array(
-    'eval' => "\$object->to->count() !operator! !value!",
+    'eval' => "!\$object->isPbfRule() && \$object->to->count() !operator! !value!",
     'arg' => TRUE,
     'ci' => array(
         'fString' => '(%PROP% 1)',
@@ -125,6 +125,9 @@ RQuery::$defaultFilters['rule']['to.count']['operators']['>,<,=,!'] = array(
 
 RQuery::$defaultFilters['rule']['from']['operators']['is.any'] = array(
     'Function' => function (RuleRQueryContext $context) {
+        if( $context->object->isPbfRule() )
+            return FALSE;
+
         return $context->object->from->isAny();
     },
     'arg' => FALSE,

--- a/lib/network-classes/ZoneStore.php
+++ b/lib/network-classes/ZoneStore.php
@@ -199,7 +199,7 @@ class ZoneStore extends ObjStore
                 derr("Zone: " . $name . " already available\n");
         }
 
-        $found = $this->find($name, null);
+        $found = $this->find($name, null, FALSE);
         if( $found !== null )
             derr("cannot create Zone named '" . $name . "' as this name is already in use ");
 

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -195,8 +195,15 @@ class AddressGroup
                     $tmp_found_addresses = $this->owner->all($tagFilter);
                     foreach( $tmp_found_addresses as $address )
                     {
-                        $this->members[] = $address;
-                        $address->addReference($this);
+                        if( $this->name() == $address->name() )
+                        {
+                            mwarning("dynamic AddressGroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
+                        }
+                        else
+                        {
+                            $this->members[] = $address;
+                            $address->addReference($this);
+                        }
                     }
                 }
             }

--- a/lib/object-classes/AddressStore.php
+++ b/lib/object-classes/AddressStore.php
@@ -765,7 +765,7 @@ class AddressStore
      **/
     public function newAddressGroup($name)
     {
-        $found = $this->find($name, null, TRUE);
+        $found = $this->find($name, null, FALSE);
         if( $found !== null )
             derr("cannot create AddressGroup named '" . $name . "' as this name is already in use");
 
@@ -788,7 +788,7 @@ class AddressStore
      **/
     public function API_newAddressGroup($name)
     {
-        $found = $this->find($name, null, TRUE);
+        $found = $this->find($name, null, FALSE);
         if( $found !== null )
             derr("cannot create AddressGroup named '" . $name . "' as this name is already in use");
 

--- a/lib/object-classes/AddressStore.php
+++ b/lib/object-classes/AddressStore.php
@@ -358,6 +358,10 @@ class AddressStore
         return count($this->_tmpAddresses);
     }
 
+    public function countRegionObjects()
+    {
+        return count($this->_regionObjects);
+    }
 
     /**
      *
@@ -653,8 +657,14 @@ class AddressStore
             if( $cleanInMemory )
                 $s->removeAll(FALSE);
         }
+        else if( $class == 'Region' )
+        {
+            unset($this->_regionObjects[$objectName]);
+            if( $cleanInMemory )
+                $s->removeAll(FALSE);
+        }
         else
-            derr('invalid class found');
+            derr('AddressStore remove - invalid class found');
 
         $s->owner = null;
 
@@ -676,8 +686,15 @@ class AddressStore
                 else
                     DH::clearDomNodeChilds($this->addressGroupRoot);
             }
+            elseif( $class == "Region" )
+            {
+                if( count($this->_regionObjects) > 0 )
+                    $this->regionRoot->removeChild($s->xmlroot);
+                else
+                    DH::clearDomNodeChilds($this->regionRoot);
+            }
             else
-                derr('unsupported');
+                derr('unsupported AddressStore remove class');
         }
 
         if( $cleanInMemory )

--- a/lib/object-classes/ObjStore.php
+++ b/lib/object-classes/ObjStore.php
@@ -91,9 +91,9 @@ class ObjStore
         return null;
     }
 
-    public function find($name )
+    public function find($name, $ref = null, $nested = TRUE )
     {
-        $f = $this->findByName( $name );
+        $f = $this->findByName( $name, null, $nested );
 
         if( $f !== null )
             return $f;

--- a/lib/object-classes/Schedule.php
+++ b/lib/object-classes/Schedule.php
@@ -241,6 +241,9 @@ class Schedule
             $valueRoot = DH::findFirstElementOrCreate("schedule-type", $this->xmlroot);
             $valueRoot = DH::findFirstElementOrCreate("recurring", $valueRoot);
             $valueRoot = DH::findFirstElementOrCreate("daily", $valueRoot);
+
+            DH::clearDomNodeChilds($valueRoot);
+
             foreach( $this->recurring_array['daily'] as $entry )
             {
                 DH::createElement($valueRoot, 'member', $entry['start']."-".$entry['end']);

--- a/lib/object-classes/Schedule.php
+++ b/lib/object-classes/Schedule.php
@@ -281,6 +281,9 @@ class Schedule
             $valueRoot = DH::findFirstElementOrCreate("recurring", $valueRoot);
             $valueRoot = DH::findFirstElementOrCreate("weekly", $valueRoot);
             $valueRoot = DH::findFirstElementOrCreate($day, $valueRoot);
+
+            DH::clearDomNodeChilds($valueRoot);
+
             foreach( $this->recurring_array['weekly'][$day] as $entry )
             {
                 DH::createElement($valueRoot, 'member', $entry['start']."-".$entry['end']);
@@ -317,6 +320,9 @@ class Schedule
         {
             $valueRoot = DH::findFirstElementOrCreate("schedule-type", $this->xmlroot);
             $valueRoot = DH::findFirstElementOrCreate("non-recurring", $valueRoot);
+
+            DH::clearDomNodeChilds($valueRoot);
+            
             foreach( $this->recurring_array['non-recurring'] as $entry )
             {
                 DH::createElement($valueRoot, 'member', $entry['start']."-".$entry['end']);

--- a/lib/object-classes/ServiceStore.php
+++ b/lib/object-classes/ServiceStore.php
@@ -667,7 +667,7 @@ class ServiceStore
      **/
     public function newServiceGroup($name)
     {
-        $found = $this->find($name, null, TRUE);
+        $found = $this->find($name, null, FALSE);
         if( $found !== null )
             derr("cannot create ServiceGroup named '" . $name . "' as this name is already in use");
 
@@ -687,7 +687,7 @@ class ServiceStore
      **/
     public function API_newServiceGroup($name)
     {
-        $found = $this->find($name, null, TRUE);
+        $found = $this->find($name, null, FALSE);
         if( $found !== null )
             derr("cannot create ServiceGroup named '" . $name . "' as this name is already in use");
 

--- a/lib/object-classes/Tag.php
+++ b/lib/object-classes/Tag.php
@@ -52,7 +52,8 @@ class Tag
     const color14 = 'black';
     const color15 = 'gold';
     const color16 = 'brown';
-    const color17 = 'dark green';
+    //all above have first character capital in Fawkes
+    const color17 = 'dark green'; //Olive in Fawkes
     //color18 not defined in PAN-OS
     const color19 = 'Maroon';
 
@@ -210,6 +211,14 @@ class Tag
     {
         if( !is_string($newColor) )
             derr('value can be text only');
+
+        if( !isset(self::$TagColors[$newColor]) )
+        {
+            if( $newColor === "Olive" )
+                $newColor = "dark green";
+            elseif( !isset( TAG::$TagColors[ $newColor ] ) )
+                $newColor = lcfirst( $newColor );
+        }
 
         if( !isset(self::$TagColors[$newColor]) )
         {

--- a/lib/rule-classes/SecurityRule.php
+++ b/lib/rule-classes/SecurityRule.php
@@ -1801,14 +1801,6 @@ class SecurityRule extends RuleWithUserID
                 $this->schedule->removeReference($this);
 
             $this->schedule = null;
-            $tmpRoot = DH::findFirstElement('schedule', $this->xmlroot);
-
-            if( $tmpRoot === FALSE )
-                return TRUE;
-
-            $this->xmlroot->removeChild($tmpRoot);
-
-
         }
         else
         {
@@ -1824,11 +1816,11 @@ class SecurityRule extends RuleWithUserID
                 $f->addReference( $this );
 
             $this->schedule = $f;
-
-            #$this->schedule = $newSchedule;
-            $tmpRoot = DH::findFirstElementOrCreate('schedule', $this->xmlroot);
-            DH::setDomNodeText($tmpRoot, $this->schedule->name());
         }
+
+        $this->rewriteSchedule_XML();
+
+
 
         return TRUE;
     }
@@ -2130,6 +2122,33 @@ class SecurityRule extends RuleWithUserID
         }
 
         return true;
+    }
+
+    public function referencedObjectRenamed($h, $oldname = "")
+    {
+        if( $this->schedule === $h )
+        {
+            $this->rewriteSchedule_XML();
+            return;
+        }
+    }
+
+    public function rewriteSchedule_XML()
+    {
+        if( $this->schedule === null )
+        {
+            $tmpRoot = DH::findFirstElement('schedule', $this->xmlroot);
+
+            if( $tmpRoot === FALSE )
+                return TRUE;
+
+            $this->xmlroot->removeChild($tmpRoot);
+        }
+        else
+        {
+            $tmpRoot = DH::findFirstElementOrCreate('schedule', $this->xmlroot);
+            DH::setDomNodeText($tmpRoot, $this->schedule->name());
+        }
     }
 
     static public $templatexml = '<entry name="**temporarynamechangeme**"><option><disable-server-response-inspection>no</disable-server-response-inspection></option><from><member>any</member></from><to><member>any</member></to><source><member>any</member></source><destination><member>any</member></destination><source-user><member>any</member></source-user><category><member>any</member></category><application><member>any</member></application><service><member>any</member></service><hip-profiles><member>any</member></hip-profiles><action>allow</action><log-start>no</log-start><log-end>yes</log-end><negate-source>no</negate-source><negate-destination>no</negate-destination><tag/><description/><disabled>no</disabled></entry>';

--- a/tests/test_actions.php
+++ b/tests/test_actions.php
@@ -80,13 +80,27 @@ $pathString = dirname(__FILE__)."/../utils/lib";
 $JSONarray = file_get_contents( $pathString."/util_action_filter.json");
 $json_a = json_decode($JSONarray, true);
 
+
+$start = FALSE;
 foreach( $json_a as $type => $UTILtype )
 {
-    #if( $type !== "rule" )
+    #if( $type === "address" || $type === "rule" )
     #    continue;
 
+
+
     $ci = array();
-    $ci['input'] = 'input/panorama-8.0.xml';
+    if( isset(PH::$args['in']) )
+    {
+        $ci['input'] = PH::$args['in'];
+
+        #if( strpos( $filterString, "location" ) !== false )
+        #    continue;
+    }
+
+    else
+        $ci['input'] = 'input/panorama-8.0.xml';
+
 
     foreach( $UTILtype['action'] as $actionName => &$action )
     {
@@ -119,6 +133,16 @@ foreach( $json_a as $type => $UTILtype )
         }
 
         $totalActionWithCiCount++;
+
+
+        //start from
+        #if( isset(PH::$args['in']) && $type === 'address' && strpos( $actionName, "display-NAT-usage" ) !== false )
+        #    $start = TRUE;
+
+        #if( !$start )
+        #    continue;
+
+
 
         print "check TYPE: " . $type . " action: " . $actionName . "\n";
 

--- a/tests/test_filters.php
+++ b/tests/test_filters.php
@@ -78,6 +78,7 @@ foreach( RQuery::$defaultFilters as $type => &$filtersByField )
     #if( $type != 'rule' )
     #    continue;
 
+    $start = false;
     foreach( $filtersByField as $fieldName => &$filtersByOperator )
     {
         foreach( $filtersByOperator['operators'] as $operator => &$filter )
@@ -101,6 +102,47 @@ foreach( RQuery::$defaultFilters as $type => &$filtersByField )
             $ci = &$filter['ci'];
 
             $filterString = str_replace('%PROP%', "{$fieldName} {$operator}", $ci['fString']);
+
+
+
+
+
+/*
+            if( strpos( $filterString, "src includes.full" ) !== false )
+                $start = true;
+
+            if( !$start )
+                continue;
+*/
+            //
+            //address problems memory leak
+            if( isset(PH::$args['in']) && $type === 'address' && strpos( $filterString, "refobjectname is.recursive" ) !== false )
+                continue;
+
+
+            if( isset(PH::$args['in']) && $type === 'rule' )
+            {
+                //something not working
+                //src included-in.full
+                //src included-in.partial
+                //src included-in.full.or.partial
+                if(strpos( $filterString, "src included-in." ) !== false )
+                    continue;
+
+                if(strpos( $filterString, "dst included-in." ) !== false )
+                    continue;
+
+                //error out
+                //Fatal error: Uncaught Error: Call to undefined method Region::includesIP4Network() in /Users/swaschkut/Documents/PAN-scripting/pan-os-php/lib/container-classes/AddressRuleContainer.php:368
+                //src includes.full
+                //src includes.partial
+                //src includes.full.or.partial
+                if(strpos( $filterString, "src includes." ) !== false )
+                    continue;
+                if(strpos( $filterString, "dst includes." ) !== false )
+                    continue;
+            }
+
 
 
             if( $type == 'rule' )
@@ -171,8 +213,18 @@ foreach( RQuery::$defaultFilters as $type => &$filtersByField )
             $output = '/dev/null';
             $ruletype = 'any';
 
+            if( isset(PH::$args['in']) )
+            {
+                $input = PH::$args['in'];
 
-            $cli = "php $util in={$ci['input']} out={$output} location={$location} actions=display 'filter={$filterString}'";
+                if( strpos( $filterString, "location" ) !== false )
+                    continue;
+            }
+
+            else
+                $input = $ci['input'];
+
+            $cli = "php $util in={$input} out={$output} location={$location} actions=display 'filter={$filterString}'";
 
             if( $type == 'rule' )
                 $cli .= " ruletype={$ruletype}";

--- a/tests/test_filters.php
+++ b/tests/test_filters.php
@@ -75,7 +75,7 @@ $missing_filters = array();
 foreach( RQuery::$defaultFilters as $type => &$filtersByField )
 {
 
-    #if( $type != 'rule' )
+    #if( $type != 'address' )
     #    continue;
 
     $start = false;
@@ -104,45 +104,13 @@ foreach( RQuery::$defaultFilters as $type => &$filtersByField )
             $filterString = str_replace('%PROP%', "{$fieldName} {$operator}", $ci['fString']);
 
 
-
-
-
 /*
-            if( strpos( $filterString, "src includes.full" ) !== false )
+            if( strpos( $filterString, "refobjectname is.recursive" ) !== false )
                 $start = true;
 
             if( !$start )
                 continue;
 */
-            //
-            //address problems memory leak
-            if( isset(PH::$args['in']) && $type === 'address' && strpos( $filterString, "refobjectname is.recursive" ) !== false )
-                continue;
-
-
-            if( isset(PH::$args['in']) && $type === 'rule' )
-            {
-                //something not working
-                //src included-in.full
-                //src included-in.partial
-                //src included-in.full.or.partial
-                if(strpos( $filterString, "src included-in." ) !== false )
-                    continue;
-
-                if(strpos( $filterString, "dst included-in." ) !== false )
-                    continue;
-
-                //error out
-                //Fatal error: Uncaught Error: Call to undefined method Region::includesIP4Network() in /Users/swaschkut/Documents/PAN-scripting/pan-os-php/lib/container-classes/AddressRuleContainer.php:368
-                //src includes.full
-                //src includes.partial
-                //src includes.full.or.partial
-                if(strpos( $filterString, "src includes." ) !== false )
-                    continue;
-                if(strpos( $filterString, "dst includes." ) !== false )
-                    continue;
-            }
-
 
 
             if( $type == 'rule' )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -515,6 +515,13 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "because object is of type REGION";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         $objectFind = $object->tags->parentCentralStore->find($context->arguments['tagName']);
         if( $objectFind === null )
             derr("tag named '{$context->arguments['tagName']}' not found");
@@ -535,6 +542,12 @@ AddressCallContext::$supportedActions[] = array(
         if( $object->isTmpAddr() )
         {
             $string = "because object is temporary";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+        elseif( $object->isRegion() )
+        {
+            $string = "because object is of type REGION";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
@@ -566,6 +579,12 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "because object is of type REGION";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
 
         $objectFind = $object->tags->parentCentralStore->find($context->arguments['tagName']);
         if( $objectFind === null )
@@ -586,6 +605,12 @@ AddressCallContext::$supportedActions[] = array(
         if( $object->isTmpAddr() )
         {
             $string = "because object is temporary";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+        elseif( $object->isRegion() )
+        {
+            $string = "because object is of type REGION";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
@@ -614,6 +639,13 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "because object is of type REGION";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         $pattern = '/' . $context->arguments['regex'] . '/';
         foreach( $object->tags->tags() as $tag )
         {
@@ -824,6 +856,11 @@ AddressCallContext::$supportedActions[] = array(
                         $lines .= $encloseFunction( (string)$object->getIPcount() );
                         $lines .= $encloseFunction($object->tags->tags());
                     }
+                }
+                elseif( $object->isRegion() )
+                {
+                    //swaschkut - 20220417
+                    //what to do here?
                 }
 
                 if( $addWhereUsed )
@@ -1611,6 +1648,11 @@ AddressCallContext::$supportedActions[] = array(
                 }
             }
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "UNSUPPORTED";
+            PH::ACTIONlog( $context, $string );
+        }
         else
         {
             $type = $object->type();
@@ -1715,14 +1757,21 @@ AddressCallContext::$supportedActions[] = array(
     'name' => 'description-Append',
     'MainFunction' => function (AddressCallContext $context) {
         $address = $context->object;
-        $description = $address->description();
 
         if( $address->isTmpAddr() )
         {
-            $string = "object is tmp";
+            $string = "object is of type TMP";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $address->isRegion() )
+        {
+            $string = "object is of type Region";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
+        $description = $address->description();
 
         $textToAppend = "";
         if( $description != "" )
@@ -1777,14 +1826,21 @@ AddressCallContext::$supportedActions[] = array(
     'name' => 'description-Delete',
     'MainFunction' => function (AddressCallContext $context) {
         $address = $context->object;
-        $description = $address->description();
 
         if( $address->isTmpAddr() )
         {
-            $string = "object is tmp";
+            $string = "object is of type TMP";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $address->isRegion() )
+        {
+            $string = "object is of type Region";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
+        $description = $address->description();
         if( $description == "" )
         {
             $string = "no description available";
@@ -1850,6 +1906,12 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $address->isRegion() )
+        {
+            $string = "object is of type Region";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
 
         if( !$address->isType_ipNetmask() )
         {
@@ -1893,6 +1955,13 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "object is of type Region";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         if( !$object->isType_ipNetmask() )
         {
             $string = "'value-set-reverse-dns' alias is compatible with ip-netmask type objects";
@@ -1939,6 +2008,13 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
+        elseif( $object->isRegion() )
+        {
+            $string = "object is of type Region";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         if( !$object->isType_FQDN() )
         {
             $string = "object is NOT of type FQDN";
@@ -2086,9 +2162,9 @@ AddressCallContext::$supportedActions[] = array(
             return;
         }
 
-        if( $object->isGroup() )
+        if( $object->isGroup() || $object->isRegion() )
         {
-            $string = "because object is address group";
+            $string = "because object is or GROUP or REGION";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
@@ -2330,7 +2406,13 @@ AddressCallContext::$supportedActions[] = array(
                     foreach( $objRef_owner->source->members() as $key =>$member )
                     {
                         if( $object === $member )
-                            $text .= $context->padding . PH::boldText( $member->value() );
+                        {
+                            if( $member->isAddress() )
+                                $text .= $context->padding . PH::boldText( $member->value() );
+                            else
+                                $text .= $context->padding . "GROUP: ".$member->name()." missing IPv4";
+                        }
+
                         else
                         {
                             if( $member->isAddress() )
@@ -2344,9 +2426,17 @@ AddressCallContext::$supportedActions[] = array(
                     {
                         $text .= " => ";
                         if( $object === $member )
-                            $text .= PH::boldText( $member->value() );
+                            if( $member->isAddress() )
+                                $text .= PH::boldText( $member->value() );
+                            else
+                                $text .= " GROUP: ".$member->name()." missing IPv4";
                         else
-                            $text .= $member->value();
+                        {
+                            if( $member->isAddress() )
+                                $text .= $member->value();
+                            else
+                                $text .= " GROUP: ".$member->name()." missing IPv4";
+                        }
                     }
 
 
@@ -2465,7 +2555,7 @@ AddressCallContext::$supportedActions['move-range2network'] = array(
     'MainFunction' => function (AddressCallContext $context) {
         $object = $context->object;
 
-        if( $object->isGroup() || !$object->isType_ipRange() )
+        if( $object->isGroup() || $object->isRegion() || !$object->isType_ipRange() )
         {
             $string = "Address object is not of type ip-range";
             PH::ACTIONstatus( $context, 'skipped', $string);

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -3303,13 +3303,20 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
                     PH::print_stdout(str_pad($string, 22) . $tmpString->textContent);
                 }
 
+                $tmpString = DH::findFirstElement('idle-for', $admin);
+                if( $tmpString !== FALSE )
+                {
+                    $string = "   - SESSION IDLE for: ";
+                    PH::print_stdout( str_pad( $string, 22 ).$tmpString->textContent);
+                }
+
                 $tmpString = DH::findFirstElement('session-expiry', $admin);
                 if( $tmpString !== FALSE )
                 {
                     $string = "   - SESSION EXPIRY: ";
                     PH::print_stdout( str_pad( $string, 22 ).$tmpString->textContent);
                 }
-
+//
 
 
                 if( $action == "delete" )

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -3306,6 +3306,8 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
                 $tmpString = DH::findFirstElement('idle-for', $admin);
                 if( $tmpString !== FALSE )
                 {
+                    $idleTime = $tmpString->textContent;
+                    $idleTime = str_replace( "s", "", $idleTime);
                     $string = "   - SESSION IDLE for: ";
                     PH::print_stdout( str_pad( $string, 22 ).$tmpString->textContent);
                 }
@@ -3321,7 +3323,7 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
 
                 if( $action == "delete" )
                 {
-                    $hours = $context->arguments['session-start-before-hours'];
+                    $hours = $context->arguments['idle-since-hours'];
                     if( is_integer($hours) )
                         derr( "argument need to be an integer" );
 
@@ -3332,11 +3334,28 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
                     $dateTime = new DateTime($sessionStart);
                     $sessiontime = $dateTime->format('Y/m/d H:i:s'); // 15th Apr 2010
 
+
+
+                    $seconds = strtotime("1970-01-01 $idleTime UTC");
+                    #PH::print_stdout( "      * idle seconds: ".$seconds );
+                    $actual = date('Y/m/d H:i:s');
+                    $idlesince = strtotime( $actual ) - $seconds;
+                    $idleTime = date("Y-m-d H:i:s", $idlesince);
+
+
+
+                    if( strpos( $adminUser,"panorama" ) !== false )
+                    {
+                        PH::ACTIONstatus( $context, "SKIPPED", "needed for Panorama connection");
+                        continue;
+                    }
+
+
                     PH::print_stdout();
-                    PH::print_stdout(  "      * Session Start : ".$sessiontime );
-                    PH::print_stdout( "      * calculated Time for deletion, if Session start before: ".$calculatedtime );
+                    PH::print_stdout(  "      * Idle since : ".$idleTime);//." - ".strtotime( $idleTime ) );
+                    PH::print_stdout( "      * deletion, if Idle before: ".$calculatedtime );//. " - ".strtotime( $calculatedtime ) );
                     #if( $time < $dateTime )
-                    if( $calculatedtime < $sessiontime )
+                    if( strtotime($calculatedtime) < strtotime($idleTime) )
                     {
                         PH::print_stdout();
                         PH::print_stdout( "      * this session is not old enough - skipped for deletion");
@@ -3370,7 +3389,7 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
     },
     'args' => array(
         'action' => array('type' => 'string', 'default' => 'display'),
-        'session-start-before-hours' => array('type' => 'string', 'default' => '1')
+        'idle-since-hours' => array('type' => 'string', 'default' => '8')
     ),
     'help' => "This Action is displaying the actual logged in admin sessions"
 );

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -729,7 +729,8 @@ RuleCallContext::$supportedActions[] = array(
     'MainFunction' => function (RuleCallContext $context) {
         $rule = $context->object;
 
-        if( ($rule->isPbfRule() && $rule->isZoneBased()) || ($rule->isDoSRule() && $rule->isZoneBasedFrom()) )
+        /** @var PbfRule $rule */
+        if( ($rule->isPbfRule() && ($rule->isZoneBased() or $rule->isInterfaceBased()) )  || ($rule->isDoSRule() && $rule->isZoneBasedFrom()) )
         {
             $string = "FROM is Zone based, not supported yet.";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
@@ -1042,6 +1043,13 @@ RuleCallContext::$supportedActions[] = array(
     'section' => 'address',
     'MainFunction' => function (RuleCallContext $context) {
         $rule = $context->object;
+
+        if( !$rule->isSecurityRule()  )
+        {
+            $string = "Rule is of type ".get_class($rule)." - not supported";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
 
         $old_srcs = $rule->source->getAll();
         $old_dsts = $rule->destination->getAll();

--- a/utils/common/actions-schedule.php
+++ b/utils/common/actions-schedule.php
@@ -31,12 +31,12 @@ ScheduleCallContext::$supportedActions['delete'] = array(
         }
         if( $context->isAPI )
         {
-            derr("action delete via API not available yet");
+            mwarning("action delete via API not available yet");
             # $object->owner->API_removeZone($object);
         }
         else
         {
-            derr("action delete not available yet");
+            mwarning("action delete not available yet");
             #$object->owner->removeZone($object);
         }
     },
@@ -54,12 +54,12 @@ ScheduleCallContext::$supportedActions['deleteforce'] = array(
         }
         if( $context->isAPI )
         {
-            derr("action delete via API not available yet");
+            mwarning("action delete via API not available yet");
             # $object->owner->API_removeZone($object);
         }
         else
         {
-            derr("action delete not available yet");
+            mwarning("action delete not available yet");
             #$object->owner->removeZone($object);
         }
     },

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -26,7 +26,7 @@ ServiceCallContext::$supportedActions[] = array(
 
         if( $object->countReferences() != 0 )
         {
-            $string = "this object is used by other objects and cannot be deleted (use deleteForce to try anyway)";
+            $string = "this object is used by other objects and cannot be deleted (use delete-Force to try anyway)";
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
@@ -36,27 +36,6 @@ ServiceCallContext::$supportedActions[] = array(
         else
             $object->owner->remove($object);
     },
-);
-
-ServiceCallContext::$supportedActions[] = array(
-    'name' => 'deleteForce',
-    'MainFunction' => function (ServiceCallContext $context) {
-        $object = $context->object;
-
-        mwarning('this action "deleteForce" is deprecated, you should use "delete-Force" instead!');
-
-        if( $object->countReferences() != 0 )
-        {
-            $string = "this object seems to be used so deletion may fail.";
-            PH::ACTIONstatus($context, "WARNING", $string);
-        }
-
-        if( $context->isAPI )
-            $object->owner->API_remove($object);
-        else
-            $object->owner->remove($object);
-    },
-    'deprecated' => 'this filter "secprof is.profile" is deprecated, you should use "secprof type.is.profile" instead!'
 );
 
 ServiceCallContext::$supportedActions[] = Array(

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -403,7 +403,7 @@ var subjectObject =
                         "arg": true,
                         "help": "returns TRUE if object IP value describe multiple IP addresses; e.g. ip-range: 10.0.0.0-10.0.0.255 will match \"ip.count > 200\"",
                         "ci": {
-                            "fString": "(%PROP%)",
+                            "fString": "(%PROP% 5)",
                             "input": "input\/panorama-8.0.xml"
                         }
                     }
@@ -503,7 +503,7 @@ var subjectObject =
             "netmask": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "!$object->isGroup() && $object->isType_ipNetmask() && $object->getNetworkMask() !operator! !value!",
+                        "eval": "!$object->isGroup() && !$object->isRegion() && $object->isType_ipNetmask() && $object->getNetworkMask() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -757,7 +757,7 @@ var subjectObject =
             "tag.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->tags->count() !operator! !value!",
+                        "eval": "!$object->isRegion() && $object->tags->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -1442,6 +1442,51 @@ var subjectObject =
                         "help": "if set to true; securityProfiles are create at SHARED level; at least one DG must be available"
                     }
                 }
+            },
+            "sp_spg-create-bp": {
+                "name": "sp_spg-create-bp",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "args": {
+                    "shared": {
+                        "type": "bool",
+                        "default": "false",
+                        "help": "if set to true; securityProfiles are create at SHARED level; at least one DG must be available"
+                    },
+                    "sp-name": {
+                        "type": "string",
+                        "default": "*nodefault*",
+                        "help": "if set, only ironskillet SP called 'Outbound' are created with the name defined"
+                    }
+                }
+            },
+            "system-admin-session": {
+                "name": "system-admin-session",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "args": {
+                    "action": {
+                        "type": "string",
+                        "default": "display"
+                    },
+                    "idle-since-hours": {
+                        "type": "string",
+                        "default": "8"
+                    }
+                },
+                "help": "This Action is displaying the actual logged in admin sessions"
+            },
+            "system-mgt-config_users": {
+                "name": "system-mgt-config_users",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "help": "This Action will display the configured Admin users on the Device"
+            },
+            "system-restart": {
+                "name": "system-restart",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "help": "This Action is rebooting the Device"
             },
             "template-add": {
                 "name": "template-add",
@@ -3293,7 +3338,7 @@ var subjectObject =
             "from.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->from->count() !operator! !value!",
+                        "eval": "!$object->isPbfRule() && $object->from->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -4154,7 +4199,7 @@ var subjectObject =
             "to.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->to->count() !operator! !value!",
+                        "eval": "!$object->isPbfRule() && $object->to->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -5273,11 +5318,6 @@ var subjectObject =
             "delete-force": {
                 "name": "delete-Force",
                 "MainFunction": {}
-            },
-            "deleteforce": {
-                "name": "deleteForce",
-                "MainFunction": {},
-                "deprecated": "this filter \"secprof is.profile\" is deprecated, you should use \"secprof type.is.profile\" instead!"
             },
             "description-append": {
                 "name": "description-Append",

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1928,6 +1928,8 @@ class MERGER extends UTIL
 
                 foreach( $objectsToSearchThrough as $object )
                 {
+                    /** @var Service $object */
+
                     if( !$object->isService() )
                         continue;
                     if( $object->isTmpSrv() )
@@ -2113,7 +2115,7 @@ class MERGER extends UTIL
                                     $text = "         ancestor name: '{$ancestor->name()}' DG: ";
                                     if( $ancestor->owner->owner->name() == "" ) $text .= "'shared'";
                                     else $text .= "'{$ancestor->owner->owner->name()}'";
-                                    $text .=  "  value: '{$ancestor->getDestPort()}' ";
+                                    $text .=  "  value: '{$ancestor->protocol()}/{$ancestor->getDestPort()}' ";
                                     PH::print_stdout( $text );
 
                                     if( $pickedObject === $object )
@@ -2128,7 +2130,7 @@ class MERGER extends UTIL
                             $text = "         ancestor name: '{$ancestor->name()}' DG: ";
                             if( $ancestor->owner->owner->name() == "" ) $text .= "'shared'";
                             else $text .= "'{$ancestor->owner->owner->name()}'";
-                            $text .=  "  value: '{$ancestor->getDestPort()}' ";
+                            $text .=  "  value: '{$ancestor->protocol()}/{$ancestor->getDestPort()}' ";
                             PH::print_stdout( $text );
 
                             if( $this->upperLevelSearch )
@@ -2351,7 +2353,7 @@ class MERGER extends UTIL
                             $text = "         ancestor name: '{$ancestor->name()}' DG: ";
                             if( $ancestor->owner->owner->name() == "" ) $text .= "'shared'";
                             else $text .= "'{$ancestor->owner->owner->name()}'";
-                            $text .=  "  value: '{$ancestor->getDestPort()}' ";
+                            $text .=  "  value: '{$ancestor->protocol()}/{$ancestor->getDestPort()}' ";
                             PH::print_stdout( $text );
 
                             if( $this->upperLevelSearch )

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2965,14 +2965,14 @@ class MERGER extends UTIL
             }
         }
 
-        $content = file_get_contents(dirname(__FILE__) . '/../common//html/export-template.html');
+        $content = file_get_contents(dirname(__FILE__) . '/../common/html/export-template.html');
         $content = str_replace('%TableHeaders%', $headers, $content);
 
         $content = str_replace('%lines%', $lines, $content);
 
         $jscontent = file_get_contents(dirname(__FILE__) . '/../common/html/jquery.min.js');
         $jscontent .= "\n";
-        $jscontent .= file_get_contents(dirname(__FILE__) . '/../common//html/jquery.stickytableheaders.min.js');
+        $jscontent .= file_get_contents(dirname(__FILE__) . '/../common/html/jquery.stickytableheaders.min.js');
         $jscontent .= "\n\$('table').stickyTableHeaders();\n";
 
         $content = str_replace('%JSCONTENT%', $jscontent, $content);

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2978,11 +2978,9 @@ class MERGER extends UTIL
         $content = str_replace('%JSCONTENT%', $jscontent, $content);
 
         if( PH::$shadow_json )
-        {
             PH::$JSON_OUT['exportcsv'] = $content;
-        }
-        else
-            file_put_contents($this->exportcsvFile, $content);
+
+        file_put_contents($this->exportcsvFile, $content);
     }
 
     private function deletedObject( $index, $keptOBJ, $removedOBJ)

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -1146,7 +1146,7 @@ class UTIL
         PH::print_stdout( " - PAN-OS APP-ID version: ".$panc_version );
         PH::print_stdout( array( $panc_version ), false, "PAN-OS APP-ID version" );
 
-        if( $this->pan->timezone !== null )
+        if( isset( $this->pan->timezone ) && $this->pan->timezone !== null )
             PH::print_stdout( " - PAN-OS Device timezone: ".$this->pan->timezone ." is used. actual time: ".date('Y/m/d H:i:s') );
 
         /*

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -402,7 +402,7 @@
                         "arg": true,
                         "help": "returns TRUE if object IP value describe multiple IP addresses; e.g. ip-range: 10.0.0.0-10.0.0.255 will match \"ip.count > 200\"",
                         "ci": {
-                            "fString": "(%PROP%)",
+                            "fString": "(%PROP% 5)",
                             "input": "input\/panorama-8.0.xml"
                         }
                     }
@@ -502,7 +502,7 @@
             "netmask": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "!$object->isGroup() && $object->isType_ipNetmask() && $object->getNetworkMask() !operator! !value!",
+                        "eval": "!$object->isGroup() && !$object->isRegion() && $object->isType_ipNetmask() && $object->getNetworkMask() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -756,7 +756,7 @@
             "tag.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->tags->count() !operator! !value!",
+                        "eval": "!$object->isRegion() && $object->tags->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -1441,6 +1441,51 @@
                         "help": "if set to true; securityProfiles are create at SHARED level; at least one DG must be available"
                     }
                 }
+            },
+            "sp_spg-create-bp": {
+                "name": "sp_spg-create-bp",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "args": {
+                    "shared": {
+                        "type": "bool",
+                        "default": "false",
+                        "help": "if set to true; securityProfiles are create at SHARED level; at least one DG must be available"
+                    },
+                    "sp-name": {
+                        "type": "string",
+                        "default": "*nodefault*",
+                        "help": "if set, only ironskillet SP called 'Outbound' are created with the name defined"
+                    }
+                }
+            },
+            "system-admin-session": {
+                "name": "system-admin-session",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "args": {
+                    "action": {
+                        "type": "string",
+                        "default": "display"
+                    },
+                    "idle-since-hours": {
+                        "type": "string",
+                        "default": "8"
+                    }
+                },
+                "help": "This Action is displaying the actual logged in admin sessions"
+            },
+            "system-mgt-config_users": {
+                "name": "system-mgt-config_users",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "help": "This Action will display the configured Admin users on the Device"
+            },
+            "system-restart": {
+                "name": "system-restart",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "help": "This Action is rebooting the Device"
             },
             "template-add": {
                 "name": "template-add",
@@ -3292,7 +3337,7 @@
             "from.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->from->count() !operator! !value!",
+                        "eval": "!$object->isPbfRule() && $object->from->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -4153,7 +4198,7 @@
             "to.count": {
                 "operators": {
                     ">,<,=,!": {
-                        "eval": "$object->to->count() !operator! !value!",
+                        "eval": "!$object->isPbfRule() && $object->to->count() !operator! !value!",
                         "arg": true,
                         "ci": {
                             "fString": "(%PROP% 1)",
@@ -5272,11 +5317,6 @@
             "delete-force": {
                 "name": "delete-Force",
                 "MainFunction": {}
-            },
-            "deleteforce": {
-                "name": "deleteForce",
-                "MainFunction": {},
-                "deprecated": "this filter \"secprof is.profile\" is deprecated, you should use \"secprof type.is.profile\" instead!"
             },
             "description-append": {
                 "name": "description-Append",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
UTILS:
* UTIL type=device | introduce idle time for actions=system-admin-session
* UTIL type=device | actions=system-admin-session:delete,8
* UTIL type=service-merger | extend output with protocol
* UTIL type=ALLOBJECTMERGER script | shadow-json and exportcsv argument will now also store HTML file locally
* class Tag | improve method setColor() - to successfully read SASE API config response
* UTIL type=service | delete deprecated actions=deleteForce - use actions=delete-Force
* class SecurityRule - introduce rewriteSchedule_XML() - use it in new method referencedObjectRenamed()

BUGFIX:
* CLASS ZoneStore/AddressStore/ObjStore/ServiceStore | bugfix to NOT search parentstore of object name during creation of new object
* class UTIL | bugfix for Fawkes config type related to timezone setting
* class Schedule | bugfix for method setRecurringDaily() - rewritexml correction
* UTIL type=rule | bugfix for actions=from-Set-Any / actions=src-dst-swap
* UTIL type=address | bugfix related to custom Region object - class Region()
* class AddressGroup | bugfix for dynamic AddressGroup - do not add own Group if tagged as member

GENERAL:
* framework | API KEY will be revert to send via URL, not using the secure method to send via Header which is available since PAN-OS 9.0
* framework | extend test_actions and test_filers