### PR TITLE
version 2.0.37

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTILS:
 * UTIL type=service | introduce new additional argument actions=exporttoexcel,FILE.HTML,resolvesrv
 * UTIL type=xml-issue | extend fix if Dynamic AddressGroup filter contains own tag
 * class AddressGroup | extend validation if dynamic AddressGroup filter contains own tag objects
+* UTIL type=addressgroup-/servicegroup-merger | add information for argument exportCSV
 
 BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTILS:
 * UTIL type=Rule | introduce 'filter=(timestamp-first-hit.fast < - 90 days)'
 * UTIL type=rule | introduce actions=action-set:[ACTION] | supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'
 * UTIL type=service | introduce new additional argument actions=exporttoexcel,FILE.HTML,resolvesrv
+* UTIL type=xml-issue | extend fix if Dynamic AddressGroup filter contains own tag
 
 BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ UTILS:
 BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama
 * class SecurityRule | bugfix for method 'API_setAction()'
+* UTIL type=ALLMERGER | argument allowaddingmissingobjects - bugfix to support this argument in type=service-group
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,7 +10,7 @@ UTILS:
 * UTIL type=addressgroup-/servicegroup-merger | add information for argument exportCSV
 
 BUGFIX:
-* UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama
+* UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet for Panorama
 * class SecurityRule | bugfix for method 'API_setAction()'
 * UTIL type=ALLMERGER | argument allowaddingmissingobjects - bugfix to support this argument in type=service-group
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTILS:
 * UTIL type=rule | introduce actions=action-set:[ACTION] | supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'
 * UTIL type=service | introduce new additional argument actions=exporttoexcel,FILE.HTML,resolvesrv
 * UTIL type=xml-issue | extend fix if Dynamic AddressGroup filter contains own tag
+* class AddressGroup | extend validation if dynamic AddressGroup filter contains own tag objects
 
 BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 CHANGELOG
 
-2.0.37
+2.0.37 (20220425)
 UTILS:
 * UTIL type=Rule | introduce 'filter=(timestamp-first-hit.fast < - 90 days)'
 * UTIL type=rule | introduce actions=action-set:[ACTION] | supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'
@@ -13,6 +13,7 @@ BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet for Panorama
 * class SecurityRule | bugfix for method 'API_setAction()'
 * UTIL type=ALLMERGER | argument allowaddingmissingobjects - bugfix to support this argument in type=service-group
+* class AddressGroup | method load_from_domxml() - extend validation to handle dynamic AddressGroup with empty filter
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTILS:
 * UTIL type=Rule | introduce 'filter=(timestamp-first-hit.fast < - 90 days)'
 * UTIL type=rule | introduce actions=action-set:[ACTION] | supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'
+* UTIL type=service | introduce new additional argument actions=exporttoexcel,FILE.HTML,resolvesrv
 
 BUGFIX:
 * UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet or Panorama

--- a/lib/network-classes/IKEGateway.php
+++ b/lib/network-classes/IKEGateway.php
@@ -136,7 +136,7 @@ class IKEGateway
                                 //check which template;
                                 /** @var Template $template1 */
                                 $template1 = $this->owner->owner->owner;
-                                print "template Name: ".$template1->name()."\n";
+                                #print "template Name: ".$template1->name()."\n";
 
                                 $references = $template1->getReferences();
                                 foreach( $references as $ref )

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -192,40 +192,53 @@ class AddressGroup
 
                             foreach( $names[1] as $key => $replaceTXT )
                             {
-                                $pattern = $names[0][$key];
-                                $replacements = "(tag has ".$replaceTXT.")";
+                                if( !empty($replaceTXT) )
+                                {
+                                    $pattern = $names[0][$key];
+                                    $replacements = "(tag has " . $replaceTXT . ")";
 
-                                $tagFilter = str_replace( $pattern, $replacements, $tagFilter );
+                                    $tagFilter = str_replace($pattern, $replacements, $tagFilter);
 
-                                $tag = $this->owner->owner->tagStore->find($replaceTXT);
-                                if( $tag !== null )
-                                    $tag->addReference($this);
+                                    $tag = $this->owner->owner->tagStore->find($replaceTXT);
+                                    if( $tag !== null )
+                                        $tag->addReference($this);
+                                    else
+                                    {
+                                        #Todo: what if TAG is in parent tagStore?
+                                        #stop throwing WARNING - as it could be that DAG filter is not based on TAG, e.g. VMware info
+                                        #mwarning( "TAG not found: ".$test." - for DAG: '".$this->name()."' in location: ".$this->owner->owner->name(), null, false );
+                                    }
+                                }
                                 else
                                 {
-                                    #Todo: what if TAG is in parent tagStore?
-                                    #stop throwing WARNING - as it could be that DAG filter is not based on TAG, e.g. VMware info
-                                    #mwarning( "TAG not found: ".$test." - for DAG: '".$this->name()."' in location: ".$this->owner->owner->name(), null, false );
+                                    #mwarning('empty dynamic AddressGroup filter : ', $xml, false);
+                                    mwarning("dynamic AddressGroup with name: " . $this->name() . " has an empty filter, you should review your XML config file", $this->xmlroot, false);
                                 }
                             }
                         }
-                        if( strpos( $tagFilter, '(tag has' ) === false )
-                        {
-                            $tagFilter = "(tag has ".$tagFilter.")";
-                        }
 
-                        $this->filter = $tagFilter;
-
-                        $tmp_found_addresses = $this->owner->all($tagFilter);
-                        foreach( $tmp_found_addresses as $address )
+                        if( !empty($tagFilter) && $tagFilter !== "(tag has )" )
                         {
-                            if( $this->name() == $address->name() )
+                            #print "|".$tagFilter."|\n";
+                            if(  strpos( $tagFilter, '(tag has' ) === false )
                             {
-                                mwarning("dynamic AddressGroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
+                                $tagFilter = "(tag has ".$tagFilter.")";
                             }
-                            else
+
+                            $this->filter = $tagFilter;
+
+                            $tmp_found_addresses = $this->owner->all($tagFilter);
+                            foreach( $tmp_found_addresses as $address )
                             {
-                                $this->members[] = $address;
-                                $address->addReference($this);
+                                if( $this->name() == $address->name() )
+                                {
+                                    mwarning("dynamic AddressGroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
+                                }
+                                else
+                                {
+                                    $this->members[] = $address;
+                                    $address->addReference($this);
+                                }
                             }
                         }
                     }

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -1662,6 +1662,18 @@ var subjectObject =
     "rule": {
         "name": "rule",
         "action": {
+            "action-set": {
+                "name": "action-Set",
+                "section": "action",
+                "MainFunction": {},
+                "args": {
+                    "action": {
+                        "type": "string",
+                        "default": "*nodefault*",
+                        "help": "supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'"
+                    }
+                }
+            },
             "app-add": {
                 "name": "app-Add",
                 "section": "app",
@@ -4147,6 +4159,15 @@ var subjectObject =
                     }
                 }
             },
+            "timestamp-first-hit.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ - 90 days"
+                    }
+                }
+            },
             "timestamp-last-hit.fast": {
                 "operators": {
                     ">,<,=,!": {
@@ -5357,9 +5378,10 @@ var subjectObject =
                         "default": "*NONE*",
                         "choices": [
                             "WhereUsed",
-                            "UsedInLocation"
+                            "UsedInLocation",
+                            "ResolveSRV"
                         ],
-                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n"
+                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - ResolveSRV\n"
                     }
                 }
             },

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1746,8 +1746,6 @@ class MERGER extends UTIL
                                 {
                                     $diff = $ancestor->getValueDiff($object);
 
-                                    print_r( $diff );
-
                                     if( count($diff['minus']) != 0 )
                                         foreach( $diff['minus'] as $d )
                                         {

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -810,6 +810,7 @@ class MERGER extends UTIL
                                     PH::print_stdout("\n *** STOPPING MERGE OPERATIONS NOW SINCE WE REACHED mergeCountLimit ({$this->mergeCountLimit})");
                                     break 2;
                                 }
+                                self::deletedObject($index, $ancestor, $object);
                                 continue;
                             }
                         }
@@ -852,6 +853,7 @@ class MERGER extends UTIL
                             }
                         }
                         PH::print_stdout($text);
+                        self::deletedObject($index, $pickedObject, $object);
                     }
                     else
                     {
@@ -870,6 +872,7 @@ class MERGER extends UTIL
                             if( $success )
                             {
                                 PH::print_stdout("    - deleting '{$object->_PANC_shortName()}'");
+                                self::deletedObject($index, $pickedObject, $object);
                                 if( $this->apiMode )
                                     //true flag needed for nested groups in a specific constellation
                                     $object->owner->API_remove($object, TRUE);
@@ -1802,6 +1805,7 @@ class MERGER extends UTIL
                                     PH::print_stdout("\n *** STOPPING MERGE OPERATIONS NOW SINCE WE REACHED mergeCountLimit ({$this->mergeCountLimit})");
                                     break 2;
                                 }
+                                self::deletedObject($index, $ancestor, $object);
                                 continue;
                             }
                         }
@@ -1845,6 +1849,7 @@ class MERGER extends UTIL
                             }
                         }
                         PH::print_stdout($text);
+                        self::deletedObject($index, $pickedObject, $object);
                     }
                     else
                     {
@@ -1853,6 +1858,7 @@ class MERGER extends UTIL
                             $object->__replaceWhereIamUsed($this->apiMode, $pickedObject, TRUE, 5);
 
                         PH::print_stdout("    - deleting '{$object->_PANC_shortName()}'");
+                        self::deletedObject($index, $pickedObject, $object);
                         if( $this->action === "merge" )
                         {
                             if( $this->apiMode )
@@ -2181,6 +2187,7 @@ class MERGER extends UTIL
                             $object->__replaceWhereIamUsed($this->apiMode, $pickedObject, TRUE, 5);
 
                         PH::print_stdout("    - deleting '{$object->_PANC_shortName()}'");
+                        self::deletedObject($index, $pickedObject, $object);
                         if( $this->action === "merge" )
                         {
                             if( $this->apiMode )

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -474,6 +474,9 @@ class MERGER extends UTIL
             if( $this->dupAlg != 'samemembers' && $this->dupAlg != 'sameportmapping' && $this->dupAlg != 'whereused' )
                 $display_error = true;
 
+            if( isset(PH::$args['allowaddingmissingobjects']) )
+                $this->addMissingObjects = TRUE;
+
             $defaultDupAlg = 'samemembers';
         }
         elseif( $this->utilType == "tag-merger" )
@@ -768,6 +771,10 @@ class MERGER extends UTIL
                                                         $ancestor->addMember($d);
                                                 }
                                             }
+                                            else
+                                            {
+                                                PH::print_stdout("      - object not found: " . $d->name() . "");
+                                            }
                                         }
 
                                     if( count($diff['plus']) != 0 )
@@ -807,6 +814,7 @@ class MERGER extends UTIL
                             }
                         }
                         PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$ancestor->owner->owner->name() );
+                        PH::print_stdout( "    - ancestor type: ".get_class( $ancestor ) );
                         continue;
                     }
 
@@ -1738,6 +1746,8 @@ class MERGER extends UTIL
                                 {
                                     $diff = $ancestor->getValueDiff($object);
 
+                                    print_r( $diff );
+
                                     if( count($diff['minus']) != 0 )
                                         foreach( $diff['minus'] as $d )
                                         {
@@ -1753,6 +1763,10 @@ class MERGER extends UTIL
                                                     else
                                                         $ancestor->addMember($d);
                                                 }
+                                            }
+                                            else
+                                            {
+                                                PH::print_stdout("      - object not found: " . $d->name() . "");
                                             }
                                         }
 
@@ -1794,6 +1808,7 @@ class MERGER extends UTIL
                             }
                         }
                         PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$ancestor->owner->owner->name() );
+                        PH::print_stdout( "    - ancestor type: ".get_class( $ancestor ) );
                         continue;
                     }
 

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -1661,6 +1661,18 @@
     "rule": {
         "name": "rule",
         "action": {
+            "action-set": {
+                "name": "action-Set",
+                "section": "action",
+                "MainFunction": {},
+                "args": {
+                    "action": {
+                        "type": "string",
+                        "default": "*nodefault*",
+                        "help": "supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'"
+                    }
+                }
+            },
             "app-add": {
                 "name": "app-Add",
                 "section": "app",
@@ -4146,6 +4158,15 @@
                     }
                 }
             },
+            "timestamp-first-hit.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ - 90 days"
+                    }
+                }
+            },
             "timestamp-last-hit.fast": {
                 "operators": {
                     ">,<,=,!": {
@@ -5356,9 +5377,10 @@
                         "default": "*NONE*",
                         "choices": [
                             "WhereUsed",
-                            "UsedInLocation"
+                            "UsedInLocation",
+                            "ResolveSRV"
                         ],
-                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n"
+                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - ResolveSRV\n"
                     }
                 }
             },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
UTILS:
* UTIL type=Rule | introduce 'filter=(timestamp-first-hit.fast < - 90 days)'
* UTIL type=rule | introduce actions=action-set:[ACTION] | supported Security Rule actions: 'allow','deny','drop','reset-client','reset-server','reset-both'
* UTIL type=service | introduce new additional argument actions=exporttoexcel,FILE.HTML,resolvesrv
* UTIL type=xml-issue | extend fix if Dynamic AddressGroup filter contains own tag
* class AddressGroup | extend validation if dynamic AddressGroup filter contains own tag objects
* UTIL type=addressgroup-/servicegroup-merger | add information for argument exportCSV

BUGFIX:
* UTIL type=address actions=delete 'filter=(object is.unused)' | bugfix for FW to not delete used objects - not fixed yet for Panorama
* class SecurityRule | bugfix for method 'API_setAction()'
* UTIL type=ALLMERGER | argument allowaddingmissingobjects - bugfix to support this argument in type=service-group
* class AddressGroup | method load_from_domxml() - extend validation to handle dynamic AddressGroup with empty filter