### PR TITLE
UTIL type=device | actions=display-shadowrule - bugfix to display rul…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ BUGFIX:
 * class PanoramaConf | bugfix for reading custom region objects on shared level
 * class PANConf | bugfix for argument loadpanoramapushedconfig
 * UTIL type=device actions=display-shadowrule - bugfix for none declared variable
+* UTIL type=device | actions=display-shadowrule - bugfix to display rule owner
 
 GENERAL:
 

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -931,6 +931,7 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
 
                         $rule = $object->$ruletype->findByUUID( $key );
                         $sub = $object;
+                        $ownerDG = $sub->name();
 
                         while( $rule === null )
                         {


### PR DESCRIPTION
…e owner

## Description
