### PR TITLE
v2.0.40 - main topic UTIL ServiceStore | bugfix if serviceGroup A has a ServiceGroup B as member, which contains ServiceGroupA

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ BUGFIX:
 * class PANConf | bugfix for argument loadpanoramapushedconfig
 * UTIL type=device actions=display-shadowrule - bugfix for none declared variable
 * UTIL type=device | actions=display-shadowrule - bugfix to display rule owner
+* UTIL type=device actions=display-shadowrule - bugfix
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ BUGFIX:
 * UTIL type=device actions=display-shadowrule - bugfix for none declared variable
 * UTIL type=device | actions=display-shadowrule - bugfix to display rule owner
 * UTIL type=device actions=display-shadowrule - bugfix
+* UTIL ServiceStore | bugfix if serviceGroup A has a ServiceGroup B as member, which contains ServiceGroupA
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTILS:
 * UTIL type=playbook | introduce argument validation
 * class AddressGroup - dynamic Address Group with filter; every kind of filter is supported - revert warning
+* class AddressGroup/ServiceGroup/pan_php_framework - improvement for stdout
 
 BUGFIX:
 * UTIL type=tag | bugfix to support correctly tag name with characters '(' and ')'  - benefit for dynamic address group filter

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTILS:
 * UTIL type=playbook | introduce argument validation
 * class AddressGroup - dynamic Address Group with filter; every kind of filter is supported - revert warning
 * class AddressGroup/ServiceGroup/pan_php_framework - improvement for stdout
+* UTIL type=service-merger | improvement to stdout - why an object is skipped {protocol/dport/sport}
 
 BUGFIX:
 * UTIL type=tag | bugfix to support correctly tag name with characters '(' and ')'  - benefit for dynamic address group filter

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTILS:
 * class AddressGroup - dynamic Address Group with filter; every kind of filter is supported - revert warning
 * class AddressGroup/ServiceGroup/pan_php_framework - improvement for stdout
 * UTIL type=service-merger | improvement to stdout - why an object is skipped {protocol/dport/sport}
+* UTIL type=service | improvements to validate loop usage in ServiceGroup
 
 BUGFIX:
 * UTIL type=tag | bugfix to support correctly tag name with characters '(' and ')'  - benefit for dynamic address group filter

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -193,7 +193,7 @@ class AddressGroup
                                 }
                             }
                             else
-                                mwarning("dynamic AddressGroup with name: " . $this->name() . " has an empty filter, you should review your XML config file", $this->xmlroot, false);
+                                mwarning("dynamic AddressGroup with name: " . $this->name() . " has an empty filter, you should review your XML config file", $this->xmlroot, false, false);
                         }
                     }
 
@@ -212,7 +212,7 @@ class AddressGroup
                         {
                             if( $this->name() == $address->name() )
                             {
-                                mwarning("dynamic AddressGroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
+                                mwarning("dynamic AddressGroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false, false);
                             }
                             else
                             {
@@ -237,12 +237,21 @@ class AddressGroup
 
                     if( isset($membersIndex[$memberName]) )
                     {
-                        mwarning("duplicated member named '{$memberName}' detected in addressgroup '{$this->name}',  you should review your XML config file", $this->xmlroot, false);
+                        mwarning("duplicated member named '{$memberName}' detected in addressgroup '{$this->name}',  you should review your XML config file", $this->xmlroot, false, false);
                         continue;
                     }
                     $membersIndex[$memberName] = TRUE;
 
                     $f = $this->owner->findOrCreate($memberName, $this, TRUE);
+
+                    if( $f->isGroup() )
+                    {
+                        if( $this->name() == $f->name() )
+                        {
+                            mwarning("addressgroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, FALSE, false);
+                            continue;
+                        }
+                    }
                     $this->members[] = $f;
 
                     if( $f->isAddress() && $f->isType_FQDN() )
@@ -801,7 +810,7 @@ class AddressGroup
             {
                 if( $this->name() == $object->name() )
                 {
-                    mwarning("addressgroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false);
+                    mwarning("addressgroup with name: " . $this->name() . " is added as subgroup to itself, you should review your XML config file", $this->xmlroot, false, false);
                     continue;
                 }
 

--- a/lib/object-classes/ServiceGroup.php
+++ b/lib/object-classes/ServiceGroup.php
@@ -588,16 +588,20 @@ class ServiceGroup
     /**
      * @return ServiceDstPortMapping
      */
-    public function dstPortMapping()
+    public function dstPortMapping( $memberArray = array())
     {
         $mapping = new ServiceDstPortMapping();
 
-        foreach( $this->members as $member )
+        if( !array_key_exists( $this->name(), $memberArray ) )
         {
-            if( $member->isTmpSrv() && $this->name() != 'service-http' && $this->name() != 'service-https' )
-                $mapping->unresolved[$member->name()] = $member;
-            $localMapping = $member->dstPortMapping();
-            $mapping->mergeWithMapping($localMapping);
+            $memberArray[ $this->name() ] = $this->name();
+            foreach( $this->members as $member )
+            {
+                if( $member->isTmpSrv() && $this->name() != 'service-http' && $this->name() != 'service-https' )
+                    $mapping->unresolved[$member->name()] = $member;
+                $localMapping = $member->dstPortMapping($memberArray);
+                $mapping->mergeWithMapping($localMapping);
+            }
         }
 
         return $mapping;
@@ -710,14 +714,20 @@ class ServiceGroup
      * @param string $objectName
      * @return bool
      */
-    public function hasNamedObjectRecursive($objectName)
+    public function hasNamedObjectRecursive($objectName, $memberArray = array())
     {
         foreach( $this->members as $o )
         {
-            if( $o->name() === $objectName )
-                return TRUE;
-            if( $o->isGroup() )
-                if( $o->hasNamedObjectRecursive($objectName) ) return TRUE;
+            if( !array_key_exists( $o->name(), $memberArray ) )
+            {
+                $memberArray[$o->name()] = $o->name();
+                if( $o->name() === $objectName )
+                    return TRUE;
+                if( $o->isGroup() )
+                    if( $o->hasNamedObjectRecursive($objectName, $memberArray) ) return TRUE;
+            }
+            else
+                return FALSE;
         }
 
         return FALSE;

--- a/lib/object-classes/ServiceStore.php
+++ b/lib/object-classes/ServiceStore.php
@@ -205,6 +205,7 @@ class ServiceStore
 
                     foreach( $sortingArray as &$tmpGroupDeps )
                     {
+                        mwarning( "servicegroup: ".$groupName." is maybe not listed as it is involved in a loop usage", null, false );
                         if( isset($tmpGroupDeps[$groupName]) )
                             unset($tmpGroupDeps[$groupName]);
                     }

--- a/lib/object-classes/ServiceStore.php
+++ b/lib/object-classes/ServiceStore.php
@@ -157,7 +157,7 @@ class ServiceStore
      * @return ServiceGroup[]
      * @var bool $sortByDependencies
      */
-    public function serviceGroups($sortByDependencies = TRUE)
+    public function serviceGroups($sortByDependencies = FALSE)
     {
         if( !$sortByDependencies )
             return $this->_serviceGroups;
@@ -191,6 +191,16 @@ class ServiceStore
                 if( count($groupDependencies) == 0 )
                 {
                     $result[] = $this->_serviceGroups[$groupName];
+                    unset($sortingArray[$groupName]);
+
+                    foreach( $sortingArray as &$tmpGroupDeps )
+                    {
+                        if( isset($tmpGroupDeps[$groupName]) )
+                            unset($tmpGroupDeps[$groupName]);
+                    }
+                }
+                elseif( count($groupDependencies) == 1 )
+                {
                     unset($sortingArray[$groupName]);
 
                     foreach( $sortingArray as &$tmpGroupDeps )

--- a/lib/pan_php_framework.php
+++ b/lib/pan_php_framework.php
@@ -687,7 +687,7 @@ function mdeb($msg)
  * @param null|DOMNode|DOMElement $object
  * @throws Exception
  */
-function mwarning($msg, $object = null, $print_backtrace = TRUE)
+function mwarning($msg, $object = null, $print_backtrace = TRUE, $print_object = TRUE)
 {
     if( !PH::$PANC_WARN )
         return;
@@ -697,7 +697,9 @@ function mwarning($msg, $object = null, $print_backtrace = TRUE)
         $class = get_class($object);
         if( $class == 'DOMNode' || $class == 'DOMElement' || is_subclass_of($object, 'DOMNode') )
         {
-            $msg .= "\nXML line #" . $object->getLineNo() . ", XPATH: " . DH::elementToPanXPath($object) . "\n" . DH::dom_to_xml($object, 0, TRUE, 3);
+            $msg .= "\n"."XML line #" . $object->getLineNo() . ", XPATH: " . DH::elementToPanXPath($object);
+            if( $print_object )
+                $msg .= "\n". DH::dom_to_xml($object, 0, TRUE, 3);
         }
     }
 
@@ -718,14 +720,14 @@ function mwarning($msg, $object = null, $print_backtrace = TRUE)
     }
 
     else
-        fwrite(STDERR, PH::boldText("\n* ** WARNING ** * ") . $msg . "\n\n");
+        fwrite(STDERR, PH::boldText("* ** WARNING ** * ") . $msg . "\n\n");
 
 
     if( $print_backtrace )
     {
         backtrace_print();
 
-        $string = "\n\n";
+        $string = "\n";
         derr_print( $string );
     }
 

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -868,7 +868,6 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                 {
                     $rule = null;
                     $replace =  null;
-                    $ownerDG = "dummy";
 
                     //uid: $key -> search rule name for uid
                     if( $classtype == "ManagedDevice" )
@@ -878,8 +877,9 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
 
                         /** @var DeviceGroup $sub */
                         $sub = $pan->findDeviceGroup($name);
-
                         $rule = $sub->$ruletype->findByUUID( $key );
+                        $ownerDG = $name;
+
                         while( $rule === null )
                         {
                             $sub = $sub->parentDeviceGroup;

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -832,7 +832,7 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                     $type_name = $managedDevice->name();
                     $countInfo = "<" . $type . ">" . $type_name . "</" . $type . ">";
 
-                    $shadowArray2 = $context->connector->getShadowInfo($countInfo, true);
+                    $shadowArray2 = $context->connector->getShadowInfo($countInfo, true, $object->name() );
                     $shadowArray = array_merge( $shadowArray, $shadowArray2 );
                 }
             }

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2160,16 +2160,31 @@ class MERGER extends UTIL
                         }
                         else
                         {
-                            $string = "    - SKIP: object name '{$pickedObject->_PANC_shortName()}'";
+                            $string = "    - SKIP: object name '{$pickedObject->_PANC_shortName()}'\n";
                             if( $pickedObject->isService() )
-                                $string .= " [with value '{$pickedObject->getDestPort()}']";
+                            {
+                                $string .= "            [protocol '{$pickedObject->protocol()}']";
+                                $string .= " [with dport value '{$pickedObject->getDestPort()}']";
+                                if( !empty($pickedObject->getSourcePort()) )
+                                    $string .= " [with sport value '{$pickedObject->getSourcePort()}']\n";
+                                else
+                                    $string .= "\n";
+                            }
+
                             else
                                 $string .= " [ServiceGroup] ";
 
-                            $string .= " is not IDENTICAL to object name: '{$tmp_service->_PANC_shortName()}'";
+                            $string .= "       is not IDENTICAL to object name: '{$tmp_service->_PANC_shortName()}'\n";
 
                             if( $tmp_service->isService() )
-                                $string .= " [with value '{$tmp_service->getDestPort()}']";
+                            {
+                                $string .= "            [protocol '{$tmp_service->protocol()}']";
+                                $string .= " [with dport value '{$tmp_service->getDestPort()}']";
+                                if( !empty($tmp_service->getSourcePort()) )
+                                    $string .= " [with sport value '{$tmp_service->getSourcePort()}']";
+                                else
+                                    $string .= "\n";
+                            }
                             else
                                 $string .= " [ServiceGroup] ";
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

main topic: 

UTILS:
* UTIL type=playbook | introduce argument validation
* class AddressGroup - dynamic Address Group with filter; every kind of filter is supported - revert warning
* class AddressGroup/ServiceGroup/pan_php_framework - improvement for stdout
* UTIL type=service-merger | improvement to stdout - why an object is skipped {protocol/dport/sport}
* UTIL type=service | improvements to validate loop usage in ServiceGroup

BUGFIX:
* UTIL type=tag | bugfix to support correctly tag name with characters '(' and ')'  - benefit for dynamic address group filter
* UTIL type=playbook | bugfix regarding supported arguments
* class PanoramaConf | bugfix for reading custom region objects on shared level
* class PANConf | bugfix for argument loadpanoramapushedconfig
* UTIL type=device actions=display-shadowrule - bugfix for none declared variable
* UTIL type=device | actions=display-shadowrule - bugfix to display rule owner
* UTIL type=device actions=display-shadowrule - bugfix
* UTIL ServiceStore | bugfix if serviceGroup A has a ServiceGroup B as member, which contains ServiceGroupA