### PR TITLE
version 2.0.42

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.0.42
 UTILS:
 * UTIL type=address 'actions=exporttoexcel:FILE.html,ResolveIP|NestedMembers' - extension with nested IP members ip resolution and count
+* UTIL type=address 'filter=(ip.count > 200)' now also working for address-groups
 
 BUGFIX;
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.0.41
+2.0.42
+UTILS:
+
+BUGFIX;
+
+GENERAL:
+
+
+2.0.41 (20220512)
 UTILS:
 * UTIL type=address-/service-merger | export also skipped objects
 * UTIL type=address actions=exportToExcel:FILE.html,resolveIP - improvement for dynamic AddressGroup

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.0.42
 UTILS:
+* UTIL type=address 'actions=exporttoexcel:FILE.html,ResolveIP|NestedMembers' - extension with nested IP members ip resolution and count
 
 BUGFIX;
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,8 +5,9 @@ UTILS:
 * UTIL type=address 'actions=exporttoexcel:FILE.html,ResolveIP|NestedMembers' - extension with nested IP members ip resolution and count
 * UTIL type=address 'filter=(ip.count > 200)' now also working for address-groups
 * UTIL type=service | introduce actions=exporttoexcel:file.html port.count | filter=(port.count ><= VALUE)
+* UTIL type=address improve: 'actions=description-Replace-Character:$$comma$$word1'
 
-BUGFIX;
+BUGFIX:
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTILS:
 * UTIL type=address 'filter=(ip.count > 200)' now also working for address-groups
 * UTIL type=service | introduce actions=exporttoexcel:file.html port.count | filter=(port.count ><= VALUE)
 * UTIL type=address improve: 'actions=description-Replace-Character:$$comma$$word1'
+* UTIL type=rule improve: 'actions=description-Replace-Character:$$comma$$word1'
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTILS:
 * UTIL type=address 'actions=exporttoexcel:FILE.html,ResolveIP|NestedMembers' - extension with nested IP members ip resolution and count
 * UTIL type=address 'filter=(ip.count > 200)' now also working for address-groups
+* UTIL type=service | introduce actions=exporttoexcel:file.html port.count | filter=(port.count ><= VALUE)
 
 BUGFIX;
 

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -153,7 +153,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 0;
-    private static $library_version_bugfix = 41;
+    private static $library_version_bugfix = 42;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/ServiceRQueryContext.php
+++ b/lib/misc-classes/ServiceRQueryContext.php
@@ -7,5 +7,20 @@
  */
 class ServiceRQueryContext extends RQueryContext
 {
+    public function ServiceCount( $object, $type = "both" )
+    {
+        $objects[] = $object;
+        $dst_port_mapping = new ServiceDstPortMapping();
+        $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects );
 
+        $dst_port_mapping->countPortmapping();
+        if( $type === "both" )
+            $calculatedCounter = $dst_port_mapping->PortCounter;
+        elseif( $type === "tcp" )
+            $calculatedCounter = $dst_port_mapping->tcpPortCounter;
+        elseif( $type === "udp" )
+            $calculatedCounter = $dst_port_mapping->udpPortCounter;
+
+        return $calculatedCounter;
+    }
 }

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1279,13 +1279,20 @@ RQuery::$defaultFilters['address']['ip.count']['operators']['>,<,=,!'] = array(
         if( $operator == '=' )
             $operator = '==';
 
-        if( $object->isGroup() || $object->isRegion() )
+        if( $object->isRegion() )
         {
             //count IP addresses
             return false;
         }
-
-        $int = $object->getIPcount();
+        elseif( $object->isGroup() )
+        {
+            $int = 0;
+            $members = $object->expand(FALSE);
+            foreach( $members as $member )
+                $int += $member->getIPcount();
+        }
+        else
+            $int = $object->getIPcount();
 
         if( $int == FALSE )
             return FALSE;

--- a/lib/misc-classes/filters/filters-Service.php
+++ b/lib/misc-classes/filters/filters-Service.php
@@ -904,4 +904,74 @@ RQuery::$defaultFilters['service']['timeout.value']['operators']['>,<,=,!'] = ar
         'input' => 'input/panorama-8.0.xml'
     )
 );
+
+RQuery::$defaultFilters['service']['port.count']['operators']['>,<,=,!'] = array(
+    'Function' => function (ServiceRQueryContext $context) {
+        $counter = $context->value;
+        $service = $context->object;
+
+        $calculatedCounter = $context->ServiceCount( $service, "both");
+
+        $operator = $context->operator;
+        if( $operator == '=' )
+            $operator = '==';
+
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 443)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['service']['port.tcp.count']['operators']['>,<,=,!'] = array(
+    'Function' => function (ServiceRQueryContext $context) {
+        $counter = $context->value;
+        $service = $context->object;
+
+        $calculatedCounter = $context->ServiceCount( $service, "tcp");
+
+        $operator = $context->operator;
+        if( $operator == '=' )
+            $operator = '==';
+
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 443)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['service']['port.udp.count']['operators']['>,<,=,!'] = array(
+    'Function' => function (ServiceRQueryContext $context) {
+        $counter = $context->value;
+        $service = $context->object;
+
+        $calculatedCounter = $context->ServiceCount( $service, "udp");
+
+        $operator = $context->operator;
+        if( $operator == '=' )
+            $operator = '==';
+
+        $operator_string = $calculatedCounter." ".$operator." ".$counter;
+        if( eval("return $operator_string;" ) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 443)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 // </editor-fold>

--- a/utils/common/RuleCallContext.php
+++ b/utils/common/RuleCallContext.php
@@ -511,6 +511,10 @@ class RuleCallContext extends CallContext
             $strMapping = array_merge( $strMapping, $unresolvedArray );
             return self::enclose($strMapping);
         }
+        if( $fieldName == 'src_ip_count' )
+        {
+            //must NOT be done on addressresolvesummary; must be done on real objects
+        }
 
         if( $fieldName == 'dst_resolved_sum' )
         {
@@ -518,6 +522,10 @@ class RuleCallContext extends CallContext
             $strMapping = $this->AddressResolveSummary( $rule, "destination", $unresolvedArray );
             $strMapping = array_merge( $strMapping, $unresolvedArray );
             return self::enclose($strMapping);
+        }
+        if( $fieldName == 'dst_ip_count' )
+        {
+            //must NOT be done on addressresolvesummary; must be done on real objects
         }
 
         if( $fieldName == 'dnat_host_resolved_sum' )

--- a/utils/common/ServiceCallContext.php
+++ b/utils/common/ServiceCallContext.php
@@ -38,4 +38,21 @@ class ServiceCallContext extends CallContext
         self::$supportedActions = $tmpArgs;
     }
 
+    public function ServiceCount( $object, $type = "both" )
+    {
+        $objects[] = $object;
+
+        $dst_port_mapping = new ServiceDstPortMapping();
+        $dst_port_mapping->mergeWithArrayOfServiceObjects( $objects);
+
+        $dst_port_mapping->countPortmapping();
+        if( $type === "both" )
+            $calculatedCounter = $dst_port_mapping->PortCounter;
+        elseif( $type === "tcp" )
+            $calculatedCounter = $dst_port_mapping->tcpPortCounter;
+        elseif( $type === "udp" )
+            $calculatedCounter = $dst_port_mapping->udpPortCounter;
+
+        return $calculatedCounter;
+    }
 }

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -869,8 +869,7 @@ AddressCallContext::$supportedActions[] = array(
                     foreach( $members as $member )
                         $counter += $member->getIPcount();
                     $lines .= $encloseFunction((string)$counter);
-
-                    $lines .= $encloseFunction( '---' );
+                    
                     $lines .= $encloseFunction($object->tags->tags());
                 }
                 elseif( $object->isAddress() )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -756,6 +756,8 @@ AddressCallContext::$supportedActions[] = array(
         $addUsedInLocation = FALSE;
         $addResolveGroupIPCoverage = FALSE;
         $addNestedMembers = FALSE;
+        $addResolveIPNestedMembers = FALSE;
+        $addNestedMembersCount = FALSE;
 
         $optionalFields = &$context->arguments['additionalFields'];
 
@@ -769,9 +771,14 @@ AddressCallContext::$supportedActions[] = array(
             $addResolveGroupIPCoverage = TRUE;
 
         if( isset($optionalFields['NestedMembers']) )
+        {
             $addNestedMembers = TRUE;
+            $addResolveIPNestedMembers = TRUE;
+            $addNestedMembersCount = TRUE;
+        }
 
-        $headers = '<th>location</th><th>name</th><th>type</th><th>value</th><th>description</th><th>IPcount</th><th>tags</th>';
+
+        $headers = '<th>location</th><th>name</th><th>type</th><th>value</th><th>description</th><th>Memberscount</th><th>IPcount</th><th>tags</th>';
 
         if( $addWhereUsed )
             $headers .= '<th>where used</th>';
@@ -781,6 +788,10 @@ AddressCallContext::$supportedActions[] = array(
             $headers .= '<th>ip resolution</th>';
         if( $addNestedMembers )
             $headers .= '<th>nested members</th>';
+        if( $addResolveIPNestedMembers )
+            $headers .= '<th>nested members ip resolution</th>';
+        if( $addNestedMembersCount )
+            $headers .= '<th>nested members count</th>';
 
         $lines = '';
         $encloseFunction = function ($value, $nowrap = TRUE) {
@@ -839,7 +850,8 @@ AddressCallContext::$supportedActions[] = array(
                     if( $object->isDynamic() )
                     {
                         $lines .= $encloseFunction('group-dynamic');
-                        $lines .= $encloseFunction('');
+                        #$lines .= $encloseFunction('');
+                        $lines .= $encloseFunction($object->members());
                     }
                     else
                     {
@@ -847,7 +859,11 @@ AddressCallContext::$supportedActions[] = array(
                         $lines .= $encloseFunction($object->members());
                     }
                     $lines .= $encloseFunction($object->description(), FALSE);
-                    $lines .= $encloseFunction('---');
+                    if( $object->isGroup() )
+                        $lines .= $encloseFunction( (string)count( $object->members() ));
+                    else
+                        $lines .= $encloseFunction( '---' );
+                    $lines .= $encloseFunction( '---' );
                     $lines .= $encloseFunction($object->tags->tags());
                 }
                 elseif( $object->isAddress() )
@@ -910,6 +926,28 @@ AddressCallContext::$supportedActions[] = array(
                     {
                         $members = $object->expand(TRUE);
                         $lines .= $encloseFunction($members);
+                    }
+                    else
+                        $lines .= $encloseFunction('');
+                }
+                if( $addResolveIPNestedMembers )
+                {
+                    if( $object->isGroup() )
+                    {   $resolve = array();
+                        $members = $object->expand(FALSE);
+                        foreach( $members as $member )
+                            $resolve[] = $member->value();
+                        $lines .= $encloseFunction($resolve);
+                    }
+                    else
+                        $lines .= $encloseFunction('');
+                }
+                if( $addNestedMembersCount )
+                {
+                    if( $object->isGroup() )
+                    {   $resolve = array();
+                        $members = $object->expand(FALSE);
+                        $lines .= $encloseFunction( (string)count($members) );
                     }
                     else
                         $lines .= $encloseFunction('');

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1971,7 +1971,7 @@ AddressCallContext::$supportedActions[] = array(
         'search' => array('type' => 'string', 'default' => '*nodefault*'),
         'replace' => array('type' => 'string', 'default' => '')
     ),
-    'help' => ''
+    'help' => 'possible variable $$comma$$ or $$pipe$$; example "actions=description-Replace-Character:$$comma$$word1"'
 );
 AddressCallContext::$supportedActions[] = array(
     'name' => 'value-host-object-add-netmask-m32',

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1968,7 +1968,7 @@ AddressCallContext::$supportedActions[] = array(
 
     },
     'args' => array(
-        'search' => array('type' => 'string', 'default' => ''),
+        'search' => array('type' => 'string', 'default' => '*nodefault*'),
         'replace' => array('type' => 'string', 'default' => '')
     ),
     'help' => ''

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -924,7 +924,7 @@ AddressCallContext::$supportedActions[] = array(
                 {
                     if( $object->isGroup() )
                     {
-                        $members = $object->expand(TRUE);
+                        $members = $object->expand(FALSE);
                         $lines .= $encloseFunction($members);
                     }
                     else

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -863,6 +863,13 @@ AddressCallContext::$supportedActions[] = array(
                         $lines .= $encloseFunction( (string)count( $object->members() ));
                     else
                         $lines .= $encloseFunction( '---' );
+
+                    $counter = 0;
+                    $members = $object->expand(FALSE);
+                    foreach( $members as $member )
+                        $counter += $member->getIPcount();
+                    $lines .= $encloseFunction((string)$counter);
+
                     $lines .= $encloseFunction( '---' );
                     $lines .= $encloseFunction($object->tags->tags());
                 }
@@ -881,6 +888,7 @@ AddressCallContext::$supportedActions[] = array(
                         $lines .= $encloseFunction($object->type());
                         $lines .= $encloseFunction($object->value());
                         $lines .= $encloseFunction($object->description(), FALSE);
+                        $lines .= $encloseFunction( '---' );
                         $lines .= $encloseFunction( (string)$object->getIPcount() );
                         $lines .= $encloseFunction($object->tags->tags());
                     }

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1933,7 +1933,16 @@ AddressCallContext::$supportedActions[] = array(
         $object = $context->object;
 
         $characterToreplace = $context->arguments['search'];
+        if( strpos($characterToreplace, '$$comma$$') !== FALSE )
+            $characterToreplace = str_replace('$$comma$$', ",", $characterToreplace);
+        if( strpos($characterToreplace, '$$pipe$$') !== FALSE )
+            $characterToreplace = str_replace('$$pipe$$', "|", $characterToreplace);
+
         $characterForreplace = $context->arguments['replace'];
+        if( strpos($characterForreplace, '$$comma$$') !== FALSE )
+            $characterForreplace = str_replace('$$comma$$', ",", $characterForreplace);
+        if( strpos($characterForreplace, '$$pipe$$') !== FALSE )
+            $characterForreplace = str_replace('$$pipe$$', "|", $characterForreplace);
 
         $description = $object->description();
 
@@ -1959,8 +1968,8 @@ AddressCallContext::$supportedActions[] = array(
 
     },
     'args' => array(
-        'search' => array('type' => 'string', 'default' => '*nodefault*'),
-        'replace' => array('type' => 'string', 'default' => '*nodefault*')
+        'search' => array('type' => 'string', 'default' => ''),
+        'replace' => array('type' => 'string', 'default' => '')
     ),
     'help' => ''
 );

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -869,7 +869,7 @@ AddressCallContext::$supportedActions[] = array(
                     foreach( $members as $member )
                         $counter += $member->getIPcount();
                     $lines .= $encloseFunction((string)$counter);
-                    
+
                     $lines .= $encloseFunction($object->tags->tags());
                 }
                 elseif( $object->isAddress() )

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -2559,7 +2559,16 @@ RuleCallContext::$supportedActions[] = array(
         $object = $context->object;
 
         $characterToreplace = $context->arguments['search'];
+        if( strpos($characterToreplace, '$$comma$$') !== FALSE )
+            $characterToreplace = str_replace('$$comma$$', ",", $characterToreplace);
+        if( strpos($characterToreplace, '$$pipe$$') !== FALSE )
+            $characterToreplace = str_replace('$$pipe$$', "|", $characterToreplace);
+
         $characterForreplace = $context->arguments['replace'];
+        if( strpos($characterForreplace, '$$comma$$') !== FALSE )
+            $characterForreplace = str_replace('$$comma$$', ",", $characterForreplace);
+        if( strpos($characterForreplace, '$$pipe$$') !== FALSE )
+            $characterForreplace = str_replace('$$pipe$$', "|", $characterForreplace);
 
         $description = $object->description();
 
@@ -2586,7 +2595,7 @@ RuleCallContext::$supportedActions[] = array(
     },
     'args' => array(
         'search' => array('type' => 'string', 'default' => '*nodefault*'),
-        'replace' => array('type' => 'string', 'default' => '*nodefault*')
+        'replace' => array('type' => 'string', 'default' => '')
     ),
     'help' => ''
 );

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -2597,7 +2597,7 @@ RuleCallContext::$supportedActions[] = array(
         'search' => array('type' => 'string', 'default' => '*nodefault*'),
         'replace' => array('type' => 'string', 'default' => '')
     ),
-    'help' => ''
+    'help' => 'possible variable $$comma$$ or $$pipe$$; example "actions=description-Replace-Character:$$comma$$word1"'
 );
 
 //                                                   //

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -288,6 +288,7 @@ ServiceCallContext::$supportedActions[] = array(
 
         $headers = '<th>location</th><th>name</th><th>type</th><th>dport</th><th>sport</th><th>timeout</th><th>members</th><th>description</th><th>tags</th>';
 
+        $headers .= '<th>port.count</th><th>port.tcp.count</th><th>port.udp.count</th>';
         if( $addWhereUsed )
             $headers .= '<th>where used</th>';
         if( $addUsedInLocation )
@@ -348,6 +349,16 @@ ServiceCallContext::$supportedActions[] = array(
                         $lines .= $encloseFunction($object->tags->tags());
                     }
                 }
+
+                $calculatedCounter = $context->ServiceCount( $object, "both" );
+                $lines .= $encloseFunction((string)$calculatedCounter);
+
+                $calculatedCounter = $context->ServiceCount( $object, "tcp" );
+                $lines .= $encloseFunction((string)$calculatedCounter);
+
+                $calculatedCounter = $context->ServiceCount( $object, "udp" );
+                $lines .= $encloseFunction((string)$calculatedCounter);
+
 
                 if( $addWhereUsed )
                 {

--- a/utils/lib/DIFF.php
+++ b/utils/lib/DIFF.php
@@ -410,7 +410,7 @@ class DIFF extends UTIL
                     {
                         $nodeContent = $node->textContent;
                         if( isset($el1ContentSorted[$nodeContent]) )
-                            mwarning('cannot have <node>'.$nodeContent.'</node> nodes witch same content. file1', $el1, false, FALSE);
+                            mwarning('cannot have <node>'.$nodeContent.'</node> nodes with same content. file1', $el1, false, FALSE);
                         else
                             $el1ContentSorted[$nodeContent] = $node;
                     }
@@ -418,7 +418,7 @@ class DIFF extends UTIL
                     {
                         $nodeContent = $node->textContent;
                         if( isset($el2ContentSorted[$nodeContent]) )
-                            mwarning('cannot have <node>'.$nodeContent.'</node> nodes witch same content. file2', $el2, false, FALSE);
+                            mwarning('cannot have <node>'.$nodeContent.'</node> nodes with same content. file2', $el2, false, FALSE);
                         else
                             $el2ContentSorted[$nodeContent] = $node;
                     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

UTILS:
* UTIL type=address 'actions=exporttoexcel:FILE.html,ResolveIP|NestedMembers' - extension with nested IP members ip resolution and count
* UTIL type=address 'filter=(ip.count > 200)' now also working for address-groups
* UTIL type=service | introduce actions=exporttoexcel:file.html port.count | filter=(port.count ><= VALUE)
* UTIL type=address improve: 'actions=description-Replace-Character:$$comma$$word1'
* UTIL type=rule improve: 'actions=description-Replace-Character:$$comma$$word1'