### PR TITLE
version 2.0.55 - bugfix for type=diff argument "filter=xyz" | type=[UTIL]-merger - introduction of dupalgoritm=identical for all util mergers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ GENERAL:
 * class TemplateStack | introduce method setName()
 * class PanoramaConf | introduce method removeTemplateStack - improve removeDeviceGroup and removeTemplate
 * class MERGER | method servicegroup_merger - correct variable name
+* test script optimisation - MERGER output adjustment
 
 
 2.0.54 (20220803)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=addressgroup-/servicegroup-/service-merger | introduce dupalgorithm=identical
 * type=servicegroup-merger | introduce childDG validation
+* type=addressgroup-/servicegroup-/merger - for childDG object move; correct hashmap object array of actual DG
 
 BUGFIX:
 * type=diff "filter=XPATH" | bugfix as filter was not used
@@ -14,6 +15,7 @@ GENERAL:
 * improve bash completion script
 * class TemplateStack | introduce method setName()
 * class PanoramaConf | introduce method removeTemplateStack - improve removeDeviceGroup and removeTemplate
+* class MERGER | method servicegroup_merger - correct variable name
 
 
 2.0.54 (20220803)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ GENERAL:
 * extend different Fawkes and Buckbeak related classes
 * improve bash completion script
 * class TemplateStack | introduce method setName()
+* class PanoramaConf | introduce method removeTemplateStack - improve removeDeviceGroup and removeTemplate
 
 
 2.0.54 (20220803)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ BUGFIX:
 GENERAL:
 * extend different Fawkes and Buckbeak related classes
 * improve bash completion script
+* class TemplateStack | introduce method setName()
 
 
 2.0.54 (20220803)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ BUGFIX:
 
 GENERAL:
 * extend different Fawkes and Buckbeak related classes
+* improve bash completion script
 
 
 2.0.54 (20220803)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,8 +2,12 @@ CHANGELOG
 
 2.0.55
 UTIL:
+* type=addressgroup-/servicegroup-/service-merger | introduce dupalgorithm=identical
+* type=servicegroup-merger | introduce childDG validation
 
 BUGFIX:
+* type=diff "filter=XPATH" | bugfix as filter was not used
+* type=UTIL-merger | fix for Buckbeak validation
 
 GENERAL:
 * extend different Fawkes and Buckbeak related classes

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -1687,7 +1687,9 @@ class PanoramaConf
             //remove DG from XML
             $xPath = "/config/devices/entry[@name='localhost.localdomain']/device-group";
             $dgNode = DH::findXPathSingleEntryOrDie($xPath, $this->xmlroot);
-            $dgNode->removeChild( $DG->xmlroot );
+
+            $DGremove = DH::findFirstElementByNameAttrOrDie('entry', $DGname, $dgNode);
+            $dgNode->removeChild( $DGremove );
 
             //remove DG from DG Meta
             if( $this->version >= 80 )
@@ -1698,7 +1700,7 @@ class PanoramaConf
             $DGmetaData = DH::findFirstElementByNameAttrOrDie('entry', $DGname, $dgMetaDataNode);
             $dgMetaDataNode->removeChild( $DGmetaData );
 
-            //Todo: cleanup memory
+            unset($this->deviceGroups[ $DGname ]);
         }
 
 
@@ -1790,7 +1792,7 @@ class PanoramaConf
     {
         $Templatename = $template->name();
 
-        $template->display_references();
+        #$template->display_references();
 
         /*
          * //warning if template is used in TemplateStack
@@ -1809,9 +1811,50 @@ class PanoramaConf
             //remove Template from XML
             $xPath = "/config/devices/entry[@name='localhost.localdomain']/template";
             $dgNode = DH::findXPathSingleEntryOrDie($xPath, $this->xmlroot);
-            $dgNode->removeChild( $template->xmlroot );
 
+            $remove = DH::findFirstElementByNameAttrOrDie('entry', $Templatename, $dgNode);
+            $dgNode->removeChild( $remove );
+
+
+        unset($this->templates[$Templatename]);
             //Todo: cleanup memory
+        //}
+    }
+
+
+    /**
+     * Remove a template.
+     * @param TemplateStack $templateStack
+     **/
+    public function removeTemplateStack( $templateStack )
+    {
+        $TemplateStackname = $templateStack->name();
+
+        #$templateStack->display_references();
+
+        /*
+         * //warning if template is used in TemplateStack
+         * //implementation missing also in actions-device line 294
+         * DeviceCallContext::$supportedActions['Template-delete'] = array(
+         *
+        $childDGs = $DG->_childDeviceGroups;
+        if( count( $childDGs ) !== 0 )
+        {
+            mwarning("DeviceGroup '$DGname' has ChildDGs. Delete of DG not possible.");
+            return;
+        }
+        else
+        {
+        */
+        //remove TemplateSTack from XML
+        $xPath = "/config/devices/entry[@name='localhost.localdomain']/template-stack";
+        $dgNode = DH::findXPathSingleEntryOrDie($xPath, $this->xmlroot);
+
+        $remove = DH::findFirstElementByNameAttrOrDie('entry', $TemplateStackname, $dgNode);
+        $dgNode->removeChild( $remove );
+
+        unset($this->templatestacks[$TemplateStackname]);
+        
         //}
     }
 

--- a/lib/device-and-system-classes/Template.php
+++ b/lib/device-and-system-classes/Template.php
@@ -83,6 +83,16 @@ class Template
         return $this->name;
     }
 
+    //Todo: setName();
+    //Problem is that this Template part is never used and can not written in XML yet, how to continue????
+    //or can it????
+    public function setName($newName)
+    {
+        $this->xmlroot->setAttribute('name', $newName);
+
+        $this->name = $newName;
+    }
+
     public function &getXPath()
     {
         $str = "/config/devices/entry[@name='localhost.localdomain']/template/entry[@name='" . $this->name . "']";
@@ -95,15 +105,7 @@ class Template
         return TRUE;
     }
 
-    //Todo: setName();
-    //Problem is that this Template part is never used and can not written in XML yet, how to continue????
-    //or can it????
-    public function setName($newName)
-    {
-        $this->xmlroot->setAttribute('name', $newName);
 
-        $this->name = $newName;
-    }
 
     public function load_from_templateXml()
     {

--- a/lib/device-and-system-classes/TemplateStack.php
+++ b/lib/device-and-system-classes/TemplateStack.php
@@ -104,6 +104,13 @@ class TemplateStack
         return $this->name;
     }
 
+    public function setName($newName)
+    {
+        $this->xmlroot->setAttribute('name', $newName);
+
+        $this->name = $newName;
+    }
+
     public function isTemplateStack()
     {
         return TRUE;

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -1714,7 +1714,7 @@ RQuery::$defaultFilters['rule']['service']['operators']['timeout.is.set'] = arra
     },
     'arg' => FALSE,
     'ci' => array(
-        'fString' => '(%PROP% 443)',
+        'fString' => '(%PROP%)',
         'input' => 'input/panorama-8.0.xml'
     )
 );

--- a/tests/test_mergers.php
+++ b/tests/test_mergers.php
@@ -103,13 +103,16 @@ foreach( $test_merger as $merger )
         $util = '../utils/pan-os-php.php type=addressgroup-merger';
         $dupalgorithm_array[] = 'SameMembers';
         $dupalgorithm_array[] = 'SameIP4Mapping';
+        $dupalgorithm_array[] = 'Identical';
         $dupalgorithm_array[] = 'Whereused';
 
     }
     elseif( $merger == 'service' )
     {
         $util = '../utils/pan-os-php.php type=service-merger';
+        $dupalgorithm_array[] = 'SameDstSrcPorts';
         $dupalgorithm_array[] = 'SamePorts';
+        $dupalgorithm_array[] = 'Identical';
         $dupalgorithm_array[] = 'Whereused';
     }
     elseif( $merger == 'servicegroup' )
@@ -117,6 +120,7 @@ foreach( $test_merger as $merger )
         $util = '../utils/pan-os-php.php type=servicegroup-merger';
         $dupalgorithm_array[] = 'SameMembers';
         $dupalgorithm_array[] = 'SamePortMapping';
+        $dupalgorithm_array[] = 'Identical';
         $dupalgorithm_array[] = 'Whereused';
     }
     elseif( $merger == 'tag' )

--- a/tests/test_utilscripts.php
+++ b/tests/test_utilscripts.php
@@ -27,7 +27,14 @@ $supportedUTILTypes = array(
     ##"xml-op-json",
     ##"bpa-generator"
 );
-
+/*
+address                    config-commit              download-predefined        license                    routing                    service                    spiffy                     traffic-log                xml-op-json
+address-merger             config-download-all        gratuitous-arp             maxmind-update             rule                       service-merger             stats                      upload                     zone
+addressgroup-merger        config-size                html-merger                override-finder            rule-merger                servicegroup-merger        system-log                 userid-mgr
+appid-enabler              device                     interface                  playbook                   schedule                   software-download          tag                        util_get-action-filter
+application                dhcp                       ironskillet-update         protocoll-number-download  securityprofile            software-preparation       tag-merger                 virtualwire
+bpa-generator              diff                       key-manager                register-ip-mgr            securityprofilegroup       software-remove            threat                     xml-issue
+ */
 
 foreach( $supportedUTILTypes as $util )
 {

--- a/utils/bash_autocompletion/pan-os-php.sh
+++ b/utils/bash_autocompletion/pan-os-php.sh
@@ -71,45 +71,57 @@ __pan-os-php_scripts()
 
 		prev2=${COMP_WORDS[COMP_CWORD-2]}
 
-		if [[ "${cur}" = "=" || "${prev}" = "=" ]] ; then
+		if [[ "${cur}" == "=" || "${prev}" == "=" ]] ; then
 			RepPatt="="
 			RepBy=""
 			cur2="${cur//$RepPatt/$RepBy}"
 
-			if [[ "${prev}" = "type" || "${prev2}" = "type" \
+			if [[ "${prev}" == "type" || "${prev2}" == "type" \
 			  ]] ; then
 
 				compopt +o nospace
 				COMPREPLY=($(compgen -W '${type[*]}' -- "${cur2}"))
-				typeargument="${COMP_WORDS[COMP_CWORD]}"
-			elif [[ "${prev}" = "actions" || "${prev2}" = "actions" \
+
+			elif [[ "${prev}" == "actions" || "${prev2}" == "actions" \
 			  ]] ; then
 
-          actions=$(jq -r ".\"${typeargument}\" | select(.action != []) | .action | keys[]" $jsonFILE )
+          for KEY in "${!COMP_WORDS[@]}"; do
+            if [[ "${COMP_WORDS[$KEY]}" == "type" ]] ; then
+              typeargument=${COMP_WORDS[$KEY+2]}
+            fi
+          done
+
+          actions=$(jq -r ".\"${typeargument}\" | select(.action != null) | .action | keys[]" $jsonFILE )
 
 			    compopt +o nospace
 			    COMPREPLY=($(compgen -W '${actions[*]}' -- "${cur2}"))
 			    actionargument="${COMP_WORDS[COMP_CWORD]}"
-			elif [[ "${prev}" = "filter" || "${prev2}" = "filter" \
+			elif [[ "${prev}" == "filter" || "${prev2}" == "filter" \
 			  ]] ; then
 
-          filters=$(jq -r ".\"${typeargument}\" | select(.filter != []) | .filter | keys[]" $jsonFILE)
+          for KEY in "${!COMP_WORDS[@]}"; do
+            if [[ "${COMP_WORDS[$KEY]}" == "type" ]] ; then
+              typeargument=${COMP_WORDS[$KEY+2]}
+            fi
+          done
+
+          filters=$(jq -r ".\"${typeargument}\" | select(.filter != null) | .filter | keys[]" $jsonFILE)
 
 			    compopt +o nospace
 			    COMPREPLY=($(compgen -W '${filters[*]}' -- "${cur2}"))
-			elif [[ "${prev}" = "location" || "${prev2}" = "location" \
+			elif [[ "${prev}" == "location" || "${prev2}" == "location" \
 			  ]] ; then
 
 			    compopt +o nospace
-			elif [[ "${prev}" = "loadplugin" || "${prev2}" = "loadplugin" \
+			elif [[ "${prev}" == "loadplugin" || "${prev2}" == "loadplugin" \
 			  ]] ; then
 
 			    compopt +o nospace
-			elif [[ "${prev}" = "template" || "${prev2}" = "template" \
+			elif [[ "${prev}" == "template" || "${prev2}" == "template" \
 			  ]] ; then
 
 			    compopt +o nospace
-			elif [[ "${prev}" = "apitimeout" || "${prev2}" = "apitimeout" \
+			elif [[ "${prev}" == "apitimeout" || "${prev2}" == "apitimeout" \
 			  ]] ; then
 
 			    compopt +o nospace
@@ -119,7 +131,7 @@ __pan-os-php_scripts()
 				compopt -o filenames
 		        COMPREPLY=( $(compgen -f -- ${cur2} ) )
 			fi
-		elif [[ "${cur}" = ":" || "${prev}" = ":" ]] ; then
+		elif [[ "${cur}" == ":" || "${prev}" == ":" ]] ; then
 		  echo ":"
     else
       # remove used argument from array
@@ -127,7 +139,7 @@ __pan-os-php_scripts()
 
       prevstring=""
       for word in ${COMP_WORDS[*]}; do
-        if [[ ${word} = "=" ]]; then
+        if [[ ${word} == "=" ]]; then
           case ${prevstring} in
             type*)
               unset 'arguments[0]'
@@ -212,7 +224,7 @@ __pan-os-php_scripts()
 			local arg compreply=""
 			COMPREPLY=($(compgen -W '${arguments[*]}' -- "${COMP_WORDS[COMP_CWORD]}"))
 
-			if [[ ${#COMPREPLY[*]} = 1 ]] && [[ ${COMPREPLY[0]} =~ "=" ]] ; then
+			if [[ ${#COMPREPLY[*]} == 1 ]] && [[ ${COMPREPLY[0]} =~ "=" ]] ; then
 				compopt -o nospace
 			else
 				compopt +o nospace
@@ -265,7 +277,7 @@ __pan-os-php_scripts()
 
 	        COMPREPLY=( $(compgen -o filenames -f -- ${cur2} ) )
 
-			if [ ${#COMPREPLY[*]} = 1 ]; then
+			if [ ${#COMPREPLY[*]} == 1 ]; then
 		        [ -d "$COMPREPLY" ] && LASTCHAR=/
 		        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
 		    fi
@@ -276,7 +288,7 @@ __pan-os-php_scripts()
 
 	        COMPREPLY=( $(compgen -o filenames -f  -- ${cur2} ) )
 
-			if [ ${#COMPREPLY[*]} = 1 ]; then
+			if [ ${#COMPREPLY[*]} == 1 ]; then
 		        [ -d "$COMPREPLY" ] && LASTCHAR=/
 		        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
 		    fi
@@ -287,7 +299,7 @@ __pan-os-php_scripts()
 
 	        COMPREPLY=( $(compgen -o filenames -f -- ${cur2} ) )
 
-	        if [ ${#COMPREPLY[*]} = 1 ]; then
+	        if [ ${#COMPREPLY[*]} == 1 ]; then
 		        [ -d "$COMPREPLY" ] && LASTCHAR=/
 		        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
 		    fi
@@ -334,6 +346,7 @@ __pan-os-php_scripts()
 	fi
 }
 
+
 if [ -n "$ZSH_VERSION" ]; then
   # assume Zsh
   echo "ZSH is not supported yet"
@@ -363,6 +376,3 @@ else
   echo "no supported SHELL"
   return 0
 fi
-
-
-

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -793,6 +793,8 @@ class MERGER extends UTIL
                             $store->add($pickedObject);
                         }
                         $tmp_address = $store->find( $pickedObject->name() );
+                        $value = $hashGenerator($tmp_address);
+                        $hashMap[$value][] = $tmp_address;
                     }
 
                     $countChildCreated++;
@@ -1819,9 +1821,8 @@ class MERGER extends UTIL
                 if( $tmp_DG_name == "" )
                     $tmp_DG_name = 'shared';
 
-                //it is normally an service
-                $tmp_address = $store->find( $pickedObject->name() );
-                if( $tmp_address == null && $this->dupAlg != "identical" )
+                $tmp_service = $store->find( $pickedObject->name() );
+                if( $tmp_service == null && $this->dupAlg != "identical" )
                 {
                     PH::print_stdout( "   * move object to DG: '".$tmp_DG_name."' : '".$pickedObject->name()."'" );
 
@@ -1852,33 +1853,35 @@ class MERGER extends UTIL
                             $pickedObject->owner->remove($pickedObject);
                             $store->add($pickedObject);
                         }
-                        $tmp_address = $store->find( $pickedObject->name() );
+                        $tmp_service = $store->find( $pickedObject->name() );
+                        $value = $hashGenerator($tmp_service);
+                        $hashMap[$value][] = $tmp_service;
                     }
 
                     $countChildCreated++;
                 }
-                elseif( $tmp_address === null )
+                elseif( $tmp_service === null )
                     continue;
                 else
                 {
-                    if( !$tmp_address->isGroup() )
+                    if( !$tmp_service->isGroup() )
                     {
-                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' of type AddressGroup can not be merged with object name: '{$tmp_address->_PANC_shortName()}' of type Address" );
-                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' of type AddressGroup can not be merged with object name: '{$tmp_service->_PANC_shortName()}' of type Address" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_service);
                         continue;
                     }
 
                     $pickedObject_value = $hashGenerator($pickedObject);
-                    $tmp_address_value = $hashGenerator($tmp_address);
+                    $tmp_service_value = $hashGenerator($tmp_service);
 
-                    if( $pickedObject_value == $tmp_address_value )
+                    if( $pickedObject_value == $tmp_service_value )
                     {
-                        PH::print_stdout( "   * keeping object '{$tmp_address->_PANC_shortName()}'" );
+                        PH::print_stdout( "   * keeping object '{$tmp_service->_PANC_shortName()}'" );
                     }
                     else
                     {
-                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject_value}'] is not IDENTICAL to object name: '{$tmp_address->_PANC_shortName()}' [with value '{$tmp_address_value}']" );
-                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject_value}'] is not IDENTICAL to object name: '{$tmp_service->_PANC_shortName()}' [with value '{$tmp_service_value}']" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_service);
                         continue;
                     }
                 }
@@ -1887,25 +1890,25 @@ class MERGER extends UTIL
                 // Merging loop finally!
                 foreach( $hash as $objectIndex => $object )
                 {
-                    if( $tmp_address === null )
+                    if( $tmp_service === null )
                         continue;
 
                     if( $this->dupAlg == 'identical' )
-                        if( $object->name() != $tmp_address->name() )
+                        if( $object->name() != $tmp_service->name() )
                         {
-                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$tmp_address->_PANC_shortName()}'");
-                            $this->skippedObject( $index, $tmp_address, $object);
+                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$tmp_service->_PANC_shortName()}'");
+                            $this->skippedObject( $index, $tmp_service, $object);
                             continue;
                         }
 
-                    if( $object !== $tmp_address )
+                    if( $object !== $tmp_service )
                     {
-                        PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_address->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
+                        PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_service->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
 
                         PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
                         if( $this->action === "merge" )
                         {
-                            $success = $object->__replaceWhereIamUsed($this->apiMode, $tmp_address, TRUE, 5);
+                            $success = $object->__replaceWhereIamUsed($this->apiMode, $tmp_service, TRUE, 5);
 
                             if( $success )
                             {

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -894,6 +894,14 @@ class MERGER extends UTIL
                         /** @var AddressGroup $ancestor */
                         if( $this->upperLevelSearch && $ancestor->isGroup() && !$ancestor->isDynamic() && $this->dupAlg != 'whereused' )
                         {
+                            if( $this->dupAlg == 'identical' )
+                                if( $object->name() != $ancestor->name() )
+                                {
+                                    PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$object->_PANC_shortName()}'");
+                                    $this->skippedObject( $index, $object, $ancestor);
+                                    continue;
+                                }
+
                             if( $hashGenerator($object) != $hashGenerator($ancestor) )
                             {
                                 $ancestor->displayValueDiff($object, 7);
@@ -938,13 +946,6 @@ class MERGER extends UTIL
 
                             if( $hashGenerator($object) == $hashGenerator($ancestor) )
                             {
-                                if( $this->dupAlg == 'identical' )
-                                    if( $pickedObject->name() != $ancestor->name() )
-                                    {
-                                        PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$pickedObject->_PANC_shortName()}'");
-                                        $this->skippedObject( $index, $pickedObject, $ancestor);
-                                        continue;
-                                    }
                                 $tmp_ancestor_DGname = $ancestor->owner->owner->name();
                                 if( $tmp_ancestor_DGname === "" )
                                     $tmp_ancestor_DGname = "shared";
@@ -984,7 +985,11 @@ class MERGER extends UTIL
                     }
 
                     if( $object === $pickedObject )
+                    {
+                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
+                    }
+
 
                     if( $this->dupAlg == 'whereused' )
                     {
@@ -1469,7 +1474,10 @@ class MERGER extends UTIL
                     }
 
                     if( $object === $pickedObject )
+                    {
+                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
+                    }
 
                     if( $this->dupAlg != 'identical' )
                     {
@@ -1949,6 +1957,14 @@ class MERGER extends UTIL
                         /** @var ServiceGroup $ancestor */
                         if( $this->upperLevelSearch && $ancestor->isGroup() )
                         {
+                            if( $this->dupAlg == 'identical' )
+                                if( $object->name() != $ancestor->name() )
+                                {
+                                    PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$object->_PANC_shortName()}'");
+                                    $this->skippedObject( $index, $object, $ancestor);
+                                    continue;
+                                }
+
                             if( $hashGenerator($object) != $hashGenerator($ancestor) )
                             {
                                 $ancestor->displayValueDiff($object, 7);
@@ -1992,13 +2008,6 @@ class MERGER extends UTIL
 
                             if( $hashGenerator($object) == $hashGenerator($ancestor) )
                             {
-                                if( $this->dupAlg == 'identical' )
-                                    if( $pickedObject->name() != $ancestor->name() )
-                                    {
-                                        PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$pickedObject->_PANC_shortName()}'");
-                                        $this->skippedObject( $index, $pickedObject, $ancestor);
-                                        continue;
-                                    }
                                 $tmp_ancestor_DGname = $ancestor->owner->owner->name();
                                 if( $tmp_ancestor_DGname === "" )
                                     $tmp_ancestor_DGname = "shared";
@@ -2037,7 +2046,10 @@ class MERGER extends UTIL
                     }
 
                     if( $object === $pickedObject )
+                    {
+                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
+                    }
 
                     if( $this->dupAlg == 'whereused' )
                     {
@@ -2489,7 +2501,10 @@ class MERGER extends UTIL
                         }
 
                         if( $object === $pickedObject )
+                        {
+                            PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                             continue;
+                        }
 
                         if( $this->dupAlg == 'identical' )
                             if( $object->name() != $pickedObject->name() )
@@ -2567,7 +2582,10 @@ class MERGER extends UTIL
                         }
 
                         if( $object === $pickedObject )
+                        {
+                            PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                             continue;
+                        }
 
                         $localMapping = $object->dstPortMapping();
                         PH::print_stdout( "    - adding the following ports to first service: " . $localMapping->mappingToText() . "" );
@@ -2972,7 +2990,10 @@ class MERGER extends UTIL
                     }
 
                     if( $object === $pickedObject )
+                    {
+                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
+                    }
 
                     if( $this->dupAlg != 'identical' )
                     {

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -154,7 +154,7 @@ class MERGER extends UTIL
             {
                 $alldevicegroup = $pan->deviceGroups;
             }
-            elseif( $pan->isFawkes() || $device->isBuckbeak() )
+            elseif( $pan->isFawkes() || $pan->isBuckbeak() )
             {
                 $subGroups = $pan->getContainers();
                 $subGroups2 = $pan->getDeviceClouds();
@@ -184,7 +184,7 @@ class MERGER extends UTIL
 
                     if( $pan->isPanorama() && isset($findLocation->parentDeviceGroup) && $findLocation->parentDeviceGroup !== null )
                         $parentStore = $findLocation->parentDeviceGroup->addressStore;
-                    elseif( ($pan->isFawkes() || $device->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
+                    elseif( ($pan->isFawkes() || $pan->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
                         $parentStore = $findLocation->parentContainer->addressStore;
                     else
                         $parentStore = $findLocation->owner->addressStore;
@@ -195,7 +195,7 @@ class MERGER extends UTIL
 
                     if( $pan->isPanorama() && isset($findLocation->parentDeviceGroup) && $findLocation->parentDeviceGroup !== null )
                         $parentStore = $findLocation->parentDeviceGroup->serviceStore;
-                    elseif( ($pan->isFawkes() || $device->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
+                    elseif( ($pan->isFawkes() || $pan->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
                         $parentStore = $findLocation->parentContainer->serviceStore;
                     else
                         $parentStore = $findLocation->owner->serviceStore;
@@ -206,7 +206,7 @@ class MERGER extends UTIL
 
                     if( $pan->isPanorama() && isset($findLocation->parentDeviceGroup) && $findLocation->parentDeviceGroup !== null )
                         $parentStore = $findLocation->parentDeviceGroup->tagStore;
-                    elseif( ($pan->isFawkes() || $device->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
+                    elseif( ($pan->isFawkes() || $pan->isBuckbeak()) && isset($current->owner->parentContainer) && $current->owner->parentContainer !== null )
                         $parentStore = $findLocation->parentContainer->tagStore;
                     else
                         $parentStore = $findLocation->owner->tagStore;
@@ -223,7 +223,7 @@ class MERGER extends UTIL
                     $childDeviceGroups = $findLocation->childDeviceGroups(TRUE);
                     $location_array[$key]['childDeviceGroups'] = $childDeviceGroups;
                 }
-                elseif( ($pan->isFawkes() || $device->isBuckbeak()) )
+                elseif( ($pan->isFawkes() || $pan->isBuckbeak()) )
                 {
                     //child Container/CloudDevices
                     //Todo: swaschkut 20210414
@@ -430,8 +430,9 @@ class MERGER extends UTIL
                 'shortHelp' => "Specifies how to detect duplicates:\n" .
                     "  - SameDstSrcPorts: objects with same Dst and Src ports will be replaced by the one picked (default)\n" .
                     "  - SamePorts: objects with same Dst ports will be replaced by the one picked\n" .
+                    "  - Identical: objects with same Dst and Src ports and same name will be replaced by the one picked\n" .
                     "  - WhereUsed: objects used exactly in the same location will be merged into 1 single object and all ports covered by these objects will be aggregated\n",
-                'argDesc' => 'SameDstSrcPorts|SamePorts|WhereUsed');
+                'argDesc' => 'SameDstSrcPorts|SamePorts|Identical|WhereUsed');
         }
         else
             $this->supportedArguments[] = array('niceName' => 'pickFilter', 'shortHelp' => 'specify a filter a pick which object will be kept while others will be replaced by this one', 'argDesc' => '(name regex /^g/)');
@@ -443,7 +444,7 @@ class MERGER extends UTIL
                     "  - SameAddress: objects with same Network-Value will be replaced by the one picked (default)\n" .
                     "  - Identical: objects with same network-value and same name will be replaced by the one picked\n" .
                     "  - WhereUsed: objects used exactly in the same location will be merged into 1 single object and all ports covered by these objects will be aggregated\n",
-                'argDesc' => 'SameAddress | Identical | WhereUsed');
+                'argDesc' => 'SameAddress|Identical|WhereUsed');
         }
         elseif( $this->utilType == "addressgroup-merger" )
         {
@@ -451,8 +452,9 @@ class MERGER extends UTIL
                 'shortHelp' => "Specifies how to detect duplicates:\n" .
                     "  - SameMembers: groups holding same members replaced by the one picked first (default)\n" .
                     "  - SameIP4Mapping: groups resolving the same IP4 coverage will be replaced by the one picked first\n" .
+                    "  - Identical: groups holding same members and same name will be replaced by the one picked\n" .
                     "  - WhereUsed: groups used exactly in the same location will be merged into 1 single groups with all members together\n",
-                'argDesc' => 'SameMembers|SameIP4Mapping|WhereUsed');
+                'argDesc' => 'SameMembers|SameIP4Mapping|Identical|WhereUsed');
         }
         elseif( $this->utilType == "servicegroup-merger" )
         {
@@ -460,8 +462,9 @@ class MERGER extends UTIL
                 'shortHelp' => "Specifies how to detect duplicates:\n" .
                     "  - SameMembers: groups holding same members replaced by the one picked first (default)\n" .
                     "  - SamePortMapping: groups resolving the same port mapping coverage will be replaced by the one picked first\n" .
+                    "  - Identical: groups holding same members and same name will be replaced by the one picked\n" .
                     "  - WhereUsed: groups used exactly in the same location will be merged into 1 single groups with all members together\n",
-                'argDesc' => 'SameMembers|SamePortMapping|WhereUsed');
+                'argDesc' => 'SameMembers|SamePortMapping|Identical|WhereUsed');
         }
         elseif( $this->utilType == "tag-merger" )
         {
@@ -471,7 +474,7 @@ class MERGER extends UTIL
                     "  - Identical: objects with same TAG-color and same name will be replaced by the one picked\n" .
                     "  - WhereUsed: objects used exactly in the same location will be merged into 1 single object and all ports covered by these objects will be aggregated\n" .
                     "  - SameName: objects with same Name\n",
-                'argDesc' => 'SameColor | Identical | WhereUsed | SameName');
+                'argDesc' => 'SameColor|Identical|WhereUsed|SameName');
         }
 
         $this->supportedArguments[] = array('niceName' => 'excludeFilter', 'shortHelp' => 'specify a filter to exclude objects from merging process entirely', 'argDesc' => '(name regex /^g/)');
@@ -505,7 +508,7 @@ class MERGER extends UTIL
         }
         elseif( $this->utilType == "addressgroup-merger" )
         {
-            if( $this->dupAlg != 'samemembers' && $this->dupAlg != 'sameip4mapping' && $this->dupAlg != 'whereused' )
+            if( $this->dupAlg != 'samemembers' && $this->dupAlg != 'sameip4mapping' && $this->dupAlg != 'identical' && $this->dupAlg != 'whereused' )
                 $display_error = true;
 
             if( isset(PH::$args['allowaddingmissingobjects']) )
@@ -515,14 +518,14 @@ class MERGER extends UTIL
         }
         elseif( $this->utilType == "service-merger" )
         {
-            if( $this->dupAlg != 'sameports' && $this->dupAlg != 'whereused' && $this->dupAlg != 'samedstsrcports' )
+            if( $this->dupAlg != 'sameports' && $this->dupAlg != 'whereused' && $this->dupAlg != 'samedstsrcports' && $this->dupAlg != 'identical' )
                 $display_error = true;
 
             $defaultDupAlg = 'samedstsrcports';
         }
         elseif( $this->utilType == "servicegroup-merger" )
         {
-            if( $this->dupAlg != 'samemembers' && $this->dupAlg != 'sameportmapping' && $this->dupAlg != 'whereused' )
+            if( $this->dupAlg != 'samemembers' && $this->dupAlg != 'sameportmapping' && $this->dupAlg != 'identical' && $this->dupAlg != 'whereused' )
                 $display_error = true;
 
             if( isset(PH::$args['allowaddingmissingobjects']) )
@@ -552,34 +555,44 @@ class MERGER extends UTIL
 
     }
 
+    function locationSettings( $tmp_location, $type, &$store, &$findLocation, &$parentStore, &$childDeviceGroups)
+    {
+        $store = $tmp_location['store'];
+        $findLocation = $tmp_location['findLocation'];
+        $parentStore = $tmp_location['parentStore'];
+        if( $this->upperLevelSearch )
+            $childDeviceGroups = $tmp_location['childDeviceGroups'];
+        else
+            $childDeviceGroups = array();
+
+        PH::print_stdout( "\n\n***********************************************\n" );
+        PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
+        if( is_string($findLocation) )
+            PH::print_stdout( " - location 'shared' found" );
+        else
+            PH::print_stdout( " - location '{$findLocation->name()}' found" );
+        PH::print_stdout( " - found {$store->count()} address Objects" );
+        PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
+        PH::print_stdout( " - computing ".$type." values database ... " );
+        sleep(1);
+    }
+
     function addressgroup_merging()
     {
         foreach( $this->location_array as $tmp_location )
         {
-            $store = $tmp_location['store'];
-            $findLocation = $tmp_location['findLocation'];
-            $parentStore = $tmp_location['parentStore'];
-            if( $this->upperLevelSearch )
-                $childDeviceGroups = $tmp_location['childDeviceGroups'];
-            else
-                $childDeviceGroups = array();
+            $store = null;
+            $findLocation = null;
+            $parentStore = null;
+            $childDeviceGroups = null;
+            $this->locationSettings( $tmp_location, "AddressGroup", $store, $findLocation,$parentStore,$childDeviceGroups);
 
-            PH::print_stdout( "\n\n***********************************************\n" );
-            PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
-            if( is_string($findLocation) )
-                PH::print_stdout( " - location 'shared' found" );
-            else
-                PH::print_stdout( " - location '{$findLocation->name()}' found" );
-            PH::print_stdout( " - found {$store->count()} address Objects" );
-            PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
-            PH::print_stdout( " - computing AddressGroup values database ... " );
-            sleep(1);
 
             /**
              * @param AddressGroup $object
              * @return string
              */
-            if( $this->dupAlg == 'samemembers' )
+            if( $this->dupAlg == 'samemembers' || $this->dupAlg == 'identical' )
                 $hashGenerator = function ($object) {
                     /** @var AddressGroup $object */
                     $value = '';
@@ -638,7 +651,10 @@ class MERGER extends UTIL
             else
                 $objectsToSearchThrough = $store->addressGroups();
 
+            $hashMap = array();
             $child_hashMap = array();
+            $upperHashMap = array();
+
             //todo: childDG/childDG to parentDG merge is always done; should it not combined to upperLevelSearch value?
             foreach( $childDeviceGroups as $dg )
             {
@@ -660,8 +676,7 @@ class MERGER extends UTIL
                 }
             }
 
-            $hashMap = array();
-            $upperHashMap = array();
+
             foreach( $objectsToSearchThrough as $object )
             {
                 if( !$object->isGroup() || $object->isDynamic() )
@@ -729,6 +744,126 @@ class MERGER extends UTIL
 
             PH::print_stdout( "\n\nNow going after each duplicates for a replacement" );
 
+            $countChildRemoved = 0;
+            $countChildCreated = 0;
+            foreach( $child_hashMap as $index => &$hash )
+            {
+                PH::print_stdout();
+                PH::print_stdout( " - value '{$index}'" );
+
+
+                $pickedObject = $this->PickObject( $hash );
+
+
+                $tmp_DG_name = $store->owner->name();
+                if( $tmp_DG_name == "" )
+                    $tmp_DG_name = 'shared';
+
+                //this is an adddressgroup object
+                $tmp_address = $store->find( $pickedObject->name() );
+                if( $tmp_address == null && $this->dupAlg != "identical" )
+                {
+                    PH::print_stdout( "   * move object to DG: '".$tmp_DG_name."' : '".$pickedObject->name()."'" );
+
+                    $skip = false;
+                    foreach( $pickedObject->members() as $memberObject )
+                        if( $store->find($memberObject->name()) === null )
+                        {
+                            PH::print_stdout(  "   * SKIPPED : this group has an object named '{$memberObject->name()} that does not exist in target location '{$tmp_DG_name}'" );
+                            $skip = true;
+                            break;
+                        }
+                    if( $skip )
+                        continue;
+
+                    if( $this->action === "merge" )
+                    {
+                        /** @var AddressStore $store */
+                        if( $this->apiMode )
+                        {
+                            $oldXpath = $pickedObject->getXPath();
+                            $pickedObject->owner->remove($pickedObject);
+                            $store->add($pickedObject);
+                            $pickedObject->API_sync();
+                            $this->pan->connector->sendDeleteRequest($oldXpath);
+                        }
+                        else
+                        {
+                            $pickedObject->owner->remove($pickedObject);
+                            $store->add($pickedObject);
+                        }
+                        $tmp_address = $store->find( $pickedObject->name() );
+                    }
+
+                    $countChildCreated++;
+                }
+                elseif( $tmp_address === null )
+                    continue;
+                else
+                {
+                    if( !$tmp_address->isGroup() )
+                    {
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' of type AddressGroup can not be merged with object name: '{$tmp_address->_PANC_shortName()}' of type Address" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        continue;
+                    }
+
+                    $pickedObject_value = $hashGenerator($pickedObject);
+                    $tmp_address_value = $hashGenerator($tmp_address);
+
+                    if( $pickedObject_value == $tmp_address_value )
+                    {
+                        PH::print_stdout( "   * keeping object '{$tmp_address->_PANC_shortName()}'" );
+                    }
+                    else
+                    {
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject_value}'] is not IDENTICAL to object name: '{$tmp_address->_PANC_shortName()}' [with value '{$tmp_address_value}']" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        continue;
+                    }
+                }
+
+
+                // Merging loop finally!
+                foreach( $hash as $objectIndex => $object )
+                {
+                    if( $tmp_address === null )
+                        continue;
+
+                    if( $this->dupAlg == 'identical' )
+                        if( $object->name() != $tmp_address->name() )
+                        {
+                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$tmp_address->_PANC_shortName()}'");
+                            $this->skippedObject( $index, $tmp_address, $object);
+                            continue;
+                        }
+
+                    if( $object !== $tmp_address )
+                    {
+                        PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_address->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
+
+                        PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
+                        if( $this->action === "merge" )
+                        {
+                            $success = $object->__replaceWhereIamUsed($this->apiMode, $tmp_address, TRUE, 5);
+
+                            if( $success )
+                            {
+                                if( $this->apiMode )
+                                    $object->owner->API_remove($object, TRUE);
+                                else
+                                    $object->owner->remove($object, TRUE);
+
+                                $countChildRemoved++;
+                            }
+                        }
+                    }
+                }
+            }
+            if( count( $child_hashMap ) >0 )
+                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddressGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} addressgroups)\n" );
+
+
             $countRemoved = 0;
             foreach( $hashMap as $index => &$hash )
             {
@@ -748,6 +883,14 @@ class MERGER extends UTIL
                     if( isset($object->ancestor) )
                     {
                         $ancestor = $object->ancestor;
+
+                        if( !$ancestor->isGroup() )
+                        {
+                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' as one ancestor is of type addressgroup");
+                            $this->skippedObject( $index, $object, $ancestor);
+                            continue;
+                        }
+
                         /** @var AddressGroup $ancestor */
                         if( $this->upperLevelSearch && $ancestor->isGroup() && !$ancestor->isDynamic() && $this->dupAlg != 'whereused' )
                         {
@@ -795,7 +938,18 @@ class MERGER extends UTIL
 
                             if( $hashGenerator($object) == $hashGenerator($ancestor) )
                             {
-                                $text = "    - group '{$object->name()} DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $ancestor->owner->owner->name() . "', deleting: " . $object->_PANC_shortName();
+                                if( $this->dupAlg == 'identical' )
+                                    if( $pickedObject->name() != $ancestor->name() )
+                                    {
+                                        PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$pickedObject->_PANC_shortName()}'");
+                                        $this->skippedObject( $index, $pickedObject, $ancestor);
+                                        continue;
+                                    }
+                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                if( $tmp_ancestor_DGname === "" )
+                                    $tmp_ancestor_DGname = "shared";
+
+                                $text = "    - group '{$object->name()} DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
                                 self::deletedObject($index, $ancestor, $object);
                                 if( $this->action === "merge" )
                                 {
@@ -820,7 +974,10 @@ class MERGER extends UTIL
                                 continue;
                             }
                         }
-                        PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$ancestor->owner->owner->name() );
+                        $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                        if( $tmp_ancestor_DGname === "" )
+                            $tmp_ancestor_DGname = "shared";
+                        PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$tmp_ancestor_DGname );
                         PH::print_stdout( "    - ancestor type: ".get_class( $ancestor ) );
                         $this->skippedObject( $index, $object, $ancestor);
                         continue;
@@ -871,6 +1028,14 @@ class MERGER extends UTIL
                             $skip = true;
                             continue;
                         }*/
+                        if( $this->dupAlg == 'identical' )
+                            if( $object->name() != $pickedObject->name() )
+                            {
+                                PH::print_stdout("    - SKIP: object name '{$pickedObject->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$object->_PANC_shortName()}'");
+                                $this->skippedObject( $index, $object, $pickedObject);
+                                continue;
+                            }
+
                         PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
                         if( $this->action === "merge" )
                         {
@@ -902,111 +1067,7 @@ class MERGER extends UTIL
                 }
             }
 
-            $countChildRemoved = 0;
-            $countChildCreated = 0;
-            foreach( $child_hashMap as $index => &$hash )
-            {
-                PH::print_stdout();
-                PH::print_stdout( " - value '{$index}'" );
-
-
-                $pickedObject = $this->PickObject( $hash );
-
-
-                $tmp_DG_name = $store->owner->name();
-                if( $tmp_DG_name == "" )
-                    $tmp_DG_name = 'shared';
-
-                $tmp_address = $store->find( $pickedObject->name() );
-                if( $tmp_address == null )
-                {
-                    PH::print_stdout( "   * move object to DG: '".$tmp_DG_name."' : '".$pickedObject->name()."'" );
-
-                    $skip = false;
-                    foreach( $pickedObject->members() as $memberObject )
-                        if( $store->find($memberObject->name()) === null )
-                        {
-                            PH::print_stdout(  "   * SKIPPED : this group has an object named '{$memberObject->name()} that does not exist in target location '{$store->owner->name()}'" );
-                            $skip = true;
-                            break;
-                        }
-                    if( $skip )
-                        continue;
-
-                    if( $this->action === "merge" )
-                    {
-                        /** @var AddressStore $store */
-                        if( $this->apiMode )
-                        {
-                            $oldXpath = $pickedObject->getXPath();
-                            $pickedObject->owner->remove($pickedObject);
-                            $store->add($pickedObject);
-                            $pickedObject->API_sync();
-                            $this->pan->connector->sendDeleteRequest($oldXpath);
-                        }
-                        else
-                        {
-                            $pickedObject->owner->remove($pickedObject);
-                            $store->add($pickedObject);
-                        }
-                    }
-
-                    $countChildCreated++;
-                }
-                else
-                {
-                    if( !$tmp_address->isGroup() )
-                    {
-                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' of type AddressGroup can not be merged with object name: '{$tmp_address->_PANC_shortName()}' of type Address" );
-                        $this->skippedObject( $index, $pickedObject, $tmp_address);
-                        continue;
-                    }
-
-                    $pickedObject_value = $hashGenerator($pickedObject);
-                    $tmp_address_value = $hashGenerator($tmp_address);
-
-                    if( $pickedObject_value == $tmp_address_value )
-                    {
-                        PH::print_stdout( "   * keeping object '{$tmp_address->_PANC_shortName()}'" );
-                    }
-                    else
-                    {
-                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject_value}'] is not IDENTICAL to object name: '{$tmp_address->_PANC_shortName()}' [with value '{$tmp_address_value}']" );
-                        $this->skippedObject( $index, $pickedObject, $tmp_address);
-                        continue;
-                    }
-                }
-
-
-                // Merging loop finally!
-                foreach( $hash as $objectIndex => $object )
-                {
-                    if( $object !== $tmp_address )
-                    {
-                        PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_address->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
-
-                        PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
-                        if( $this->action === "merge" )
-                        {
-                            $success = $object->__replaceWhereIamUsed($this->apiMode, $tmp_address, TRUE, 5);
-
-                            if( $success )
-                            {
-                                if( $this->apiMode )
-                                    $object->owner->API_remove($object, TRUE);
-                                else
-                                    $object->owner->remove($object, TRUE);
-
-                                $countChildRemoved++;
-                            }
-                        }
-                    }
-                }
-            }
-
             PH::print_stdout( "\n\nDuplicates removal is now done. Number of objects after cleanup: '{$store->countAddressGroups()}' (removed {$countRemoved} groups)\n" );
-            if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddresses()}' (removed/created {$countChildRemoved}/{$countChildCreated} addresses)\n" );
 
         }    
     }
@@ -1015,24 +1076,12 @@ class MERGER extends UTIL
     {
         foreach( $this->location_array as $tmp_location )
         {
-            $store = $tmp_location['store'];
-            $findLocation = $tmp_location['findLocation'];
-            $parentStore = $tmp_location['parentStore'];
-            if( $this->upperLevelSearch )
-                $childDeviceGroups = $tmp_location['childDeviceGroups'];
-            else
-                $childDeviceGroups = array();
+            $store = null;
+            $findLocation = null;
+            $parentStore = null;
+            $childDeviceGroups = null;
+            $this->locationSettings( $tmp_location, "Address", $store, $findLocation,$parentStore,$childDeviceGroups);
 
-            PH::print_stdout( "\n\n***********************************************\n" );
-            PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
-            if( is_string($findLocation) )
-                PH::print_stdout( " - location 'shared' found" );
-            else
-                PH::print_stdout( " - location '{$findLocation->name()}' found" );
-            PH::print_stdout( " - found {$store->countAddresses()} address Objects" );
-            PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
-            PH::print_stdout( " - computing address values database ... " );
-            sleep(1);
 
 //
 // Building a hash table of all address objects with same value
@@ -1277,6 +1326,9 @@ class MERGER extends UTIL
                 // Merging loop finally!
                 foreach( $hash as $objectIndex => $object )
                 {
+                    if( $tmp_address === null )
+                        continue;
+
                     if( $this->dupAlg == 'identical' )
                         if( $object->name() != $tmp_address->name() )
                         {
@@ -1356,7 +1408,11 @@ class MERGER extends UTIL
                                 if( $this->action === "merge" )
                                     $object->merge_tag_description_to($ancestor, $this->apiMode);
 
-                                $text = "    - object '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $ancestor->owner->owner->name() . "', deleting: " . $object->_PANC_shortName();
+                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                if( $tmp_ancestor_DGname === "" )
+                                    $tmp_ancestor_DGname = "'shared'";
+
+                                $text = "    - object '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
                                 self::deletedObject($index, $ancestor, $object);
 
                                 if( $this->action === "merge" )
@@ -1371,10 +1427,7 @@ class MERGER extends UTIL
                                 PH::print_stdout($text);
 
                                 $text = "         ancestor name: '{$ancestor->name()}' DG: ";
-                                if( $ancestor->owner->owner->name() == "" )
-                                    $text .= "'shared'";
-                                else
-                                    $text .= "'{$ancestor->owner->owner->name()}'";
+                                $text .= "'{$tmp_ancestor_DGname}'";
                                 $text .= "  value: '{$ancestor->value()}' ";
                                 PH::print_stdout($text);
 
@@ -1576,30 +1629,18 @@ class MERGER extends UTIL
     {
         foreach( $this->location_array as $tmp_location )
         {
-            $store = $tmp_location['store'];
-            $findLocation = $tmp_location['findLocation'];
-            $parentStore = $tmp_location['parentStore'];
-            if( $this->upperLevelSearch )
-                $childDeviceGroups = $tmp_location['childDeviceGroups'];
-            else
-                $childDeviceGroups = array();
+            $store = null;
+            $findLocation = null;
+            $parentStore = null;
+            $childDeviceGroups = null;
+            $this->locationSettings( $tmp_location, "ServiceGroup", $store,$findLocation,$parentStore,$childDeviceGroups);
 
-            PH::print_stdout( "\n\n***********************************************\n" );
-            PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
-            if( is_string($findLocation) )
-                PH::print_stdout( " - location 'shared' found" );
-            else
-                PH::print_stdout( " - location '{$findLocation->name()}' found" );
-            PH::print_stdout( " - found {$store->count()} services" );
-            PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
-            PH::print_stdout( " - computing ServiceGroup values database ... " );
-            sleep(1);
 
             /**
              * @param ServiceGroup $object
              * @return string
              */
-            if( $this->dupAlg == 'samemembers' )
+            if( $this->dupAlg == 'samemembers' || $this->dupAlg == 'identical' )
                 $hashGenerator = function ($object) {
                     /** @var ServiceGroup $object */
                     $value = '';
@@ -1655,6 +1696,28 @@ class MERGER extends UTIL
                 $objectsToSearchThrough = $store->nestedPointOfView();
             else
                 $objectsToSearchThrough = $store->serviceGroups();
+
+            $child_hashMap = array();
+            //todo: childDG/childDG to parentDG merge is always done; should it not combined to upperLevelSearch value?
+            foreach( $childDeviceGroups as $dg )
+            {
+                /** @var DeviceGroup $dg */
+                foreach( $dg->serviceStore->serviceGroups() as $object )
+                {
+                    if( !$object->isGroup() )
+                        continue;
+
+                    if( $this->excludeFilter !== null && $this->excludeFilter->matchSingleObject(array('object' => $object, 'nestedQueries' => &$nestedQueries)) )
+                        continue;
+
+                    $value = $hashGenerator($object);
+                    if( $value === null )
+                        continue;
+
+                    #PH::print_stdout( "add objNAME: " . $object->name() . " DG: " . $object->owner->owner->name() );
+                    $child_hashMap[$value][] = $object;
+                }
+            }
 
             $hashMap = array();
             $upperHashMap = array();
@@ -1716,11 +1779,143 @@ class MERGER extends UTIL
                     $countConcernedObjects += count($hash);
             }
             unset($hash);
-
+            $countConcernedChildObjects = 0;
+            foreach( $child_hashMap as $index => &$hash )
+            {
+                if( count($hash) == 1 && !isset($upperHashMap[$index]) && !isset(reset($hash)->ancestor) )
+                    unset($child_hashMap[$index]);
+                else
+                    $countConcernedChildObjects += count($hash);
+            }
+            unset($hash);
 
             PH::print_stdout( " - found " . count($hashMap) . " duplicate values totalling {$countConcernedObjects} groups which are duplicate" );
 
+            PH::print_stdout( " - found " . count($child_hashMap) . " duplicates childDG values totalling {$countConcernedChildObjects} address objects which are duplicate" );
+
+
             PH::print_stdout( "\n\nNow going after each duplicates for a replacement" );
+
+            $countChildRemoved = 0;
+            $countChildCreated = 0;
+            foreach( $child_hashMap as $index => &$hash )
+            {
+                PH::print_stdout();
+                PH::print_stdout( " - value '{$index}'" );
+
+
+                $pickedObject = $this->PickObject( $hash );
+
+
+                $tmp_DG_name = $store->owner->name();
+                if( $tmp_DG_name == "" )
+                    $tmp_DG_name = 'shared';
+
+                //it is normally an service
+                $tmp_address = $store->find( $pickedObject->name() );
+                if( $tmp_address == null && $this->dupAlg != "identical" )
+                {
+                    PH::print_stdout( "   * move object to DG: '".$tmp_DG_name."' : '".$pickedObject->name()."'" );
+
+                    $skip = false;
+                    foreach( $pickedObject->members() as $memberObject )
+                        if( $store->find($memberObject->name()) === null )
+                        {
+                            PH::print_stdout(  "   * SKIPPED : this group has an object named '{$memberObject->name()} that does not exist in target location '{$tmp_DG_name}'" );
+                            $skip = true;
+                            break;
+                        }
+                    if( $skip )
+                        continue;
+
+                    if( $this->action === "merge" )
+                    {
+                        /** @var AddressStore $store */
+                        if( $this->apiMode )
+                        {
+                            $oldXpath = $pickedObject->getXPath();
+                            $pickedObject->owner->remove($pickedObject);
+                            $store->add($pickedObject);
+                            $pickedObject->API_sync();
+                            $this->pan->connector->sendDeleteRequest($oldXpath);
+                        }
+                        else
+                        {
+                            $pickedObject->owner->remove($pickedObject);
+                            $store->add($pickedObject);
+                        }
+                        $tmp_address = $store->find( $pickedObject->name() );
+                    }
+
+                    $countChildCreated++;
+                }
+                elseif( $tmp_address === null )
+                    continue;
+                else
+                {
+                    if( !$tmp_address->isGroup() )
+                    {
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' of type AddressGroup can not be merged with object name: '{$tmp_address->_PANC_shortName()}' of type Address" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        continue;
+                    }
+
+                    $pickedObject_value = $hashGenerator($pickedObject);
+                    $tmp_address_value = $hashGenerator($tmp_address);
+
+                    if( $pickedObject_value == $tmp_address_value )
+                    {
+                        PH::print_stdout( "   * keeping object '{$tmp_address->_PANC_shortName()}'" );
+                    }
+                    else
+                    {
+                        PH::print_stdout( "    - SKIP: object name '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject_value}'] is not IDENTICAL to object name: '{$tmp_address->_PANC_shortName()}' [with value '{$tmp_address_value}']" );
+                        $this->skippedObject( $index, $pickedObject, $tmp_address);
+                        continue;
+                    }
+                }
+
+
+                // Merging loop finally!
+                foreach( $hash as $objectIndex => $object )
+                {
+                    if( $tmp_address === null )
+                        continue;
+
+                    if( $this->dupAlg == 'identical' )
+                        if( $object->name() != $tmp_address->name() )
+                        {
+                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$tmp_address->_PANC_shortName()}'");
+                            $this->skippedObject( $index, $tmp_address, $object);
+                            continue;
+                        }
+
+                    if( $object !== $tmp_address )
+                    {
+                        PH::print_stdout("    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_address->owner->owner->name() . "', deleting: " . $object->_PANC_shortName());
+
+                        PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
+                        if( $this->action === "merge" )
+                        {
+                            $success = $object->__replaceWhereIamUsed($this->apiMode, $tmp_address, TRUE, 5);
+
+                            if( $success )
+                            {
+                                if( $this->apiMode )
+                                    $object->owner->API_remove($object, TRUE);
+                                else
+                                    $object->owner->remove($object, TRUE);
+
+                                $countChildRemoved++;
+                            }
+                        }
+                    }
+                }
+            }
+            if( count( $child_hashMap ) >0 )
+                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServiceGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} servicegroups)\n" );
+
+
 
             $countRemoved = 0;
             foreach( $hashMap as $index => &$hash )
@@ -1728,9 +1923,9 @@ class MERGER extends UTIL
                 PH::print_stdout();
 
                 if( $this->dupAlg == 'sameportmapping' )
-                {
                     PH::print_stdout(" - value '{$index}'");
-                }
+                else
+                    PH::print_stdout(" - value '{$index}'");
 
                 $setList = array();
                 foreach( $hash as $object )
@@ -1797,7 +1992,17 @@ class MERGER extends UTIL
 
                             if( $hashGenerator($object) == $hashGenerator($ancestor) )
                             {
-                                $text = "    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $ancestor->owner->owner->name() . "', deleting: " . $object->_PANC_shortName();
+                                if( $this->dupAlg == 'identical' )
+                                    if( $pickedObject->name() != $ancestor->name() )
+                                    {
+                                        PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$pickedObject->_PANC_shortName()}'");
+                                        $this->skippedObject( $index, $pickedObject, $ancestor);
+                                        continue;
+                                    }
+                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                if( $tmp_ancestor_DGname === "" )
+                                    $tmp_ancestor_DGname = "shared";
+                                $text = "    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
                                 self::deletedObject($index, $pickedObject, $object);
                                 if( $this->action === "merge" )
                                 {
@@ -1822,7 +2027,10 @@ class MERGER extends UTIL
                                 continue;
                             }
                         }
-                        PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$ancestor->owner->owner->name() );
+                        $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                        if( $tmp_ancestor_DGname === "" )
+                            $tmp_ancestor_DGname = "shared";
+                        PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$tmp_ancestor_DGname );
                         PH::print_stdout( "    - ancestor type: ".get_class( $ancestor ) );
                         $this->skippedObject( $index, $object, $ancestor);
                         continue;
@@ -1867,6 +2075,14 @@ class MERGER extends UTIL
                     }
                     else
                     {
+                        if( $this->dupAlg == 'identical' )
+                            if( $object->name() != $pickedObject->name() )
+                            {
+                                PH::print_stdout("    - SKIP: object name '{$pickedObject->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$object->_PANC_shortName()}'");
+                                $this->skippedObject( $index, $object, $pickedObject);
+                                continue;
+                            }
+
                         PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
                         if( $this->action === "merge" )
                             $object->__replaceWhereIamUsed($this->apiMode, $pickedObject, TRUE, 5);
@@ -1903,24 +2119,11 @@ class MERGER extends UTIL
     {
         foreach( $this->location_array as $tmp_location )
         {
-            $store = $tmp_location['store'];
-            $findLocation = $tmp_location['findLocation'];
-            $parentStore = $tmp_location['parentStore'];
-            if( $this->upperLevelSearch )
-                $childDeviceGroups = $tmp_location['childDeviceGroups'];
-            else
-                $childDeviceGroups = array();
-
-            PH::print_stdout( "\n\n***********************************************\n" );
-            PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
-            if( is_string($findLocation) )
-                PH::print_stdout( " - location 'shared' found" );
-            else
-                PH::print_stdout( " - location '{$findLocation->name()}' found" );
-            PH::print_stdout( " - found {$store->countServices()} services" );
-            PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
-            PH::print_stdout( " - computing service values database ... " );
-            sleep(1);
+            $store = null;
+            $findLocation = null;
+            $parentStore = null;
+            $childDeviceGroups = null;
+            $this->locationSettings( $tmp_location, "Service", $store, $findLocation,$parentStore,$childDeviceGroups);
 
 
 //
@@ -1935,7 +2138,7 @@ class MERGER extends UTIL
             $child_hashMap = array();
             $child_NamehashMap = array();
             $upperHashMap = array();
-            if( $this->dupAlg == 'sameports' || $this->dupAlg == 'samedstsrcports' )
+            if( $this->dupAlg == 'sameports' || $this->dupAlg == 'samedstsrcports' || $this->dupAlg == 'identical' )
             {
                 //todo: childDG/childDG to parentDG merge is always done; should it not combined to upperLevelSearch value?
                 foreach( $childDeviceGroups as $dg )
@@ -2043,7 +2246,7 @@ class MERGER extends UTIL
             PH::print_stdout( "\n\nNow going after each duplicates for a replacement" );
 
             $countRemoved = 0;
-            if( $this->dupAlg == 'sameports' || $this->dupAlg == 'samedstsrcports' )
+            if( $this->dupAlg == 'sameports' || $this->dupAlg == 'samedstsrcports' || $this->dupAlg == 'identical' )
             {
                 $countChildRemoved = 0;
                 $countChildCreated = 0;
@@ -2062,7 +2265,7 @@ class MERGER extends UTIL
 
                     /** @var Service $tmp_service */
                     $tmp_service = $store->find( $pickedObject->name() );
-                    if( $tmp_service == null )
+                    if( $tmp_service == null && $this->dupAlg != 'identical'  )
                     {
                         if( isset( $child_NamehashMap[ $pickedObject->name() ] ) )
                         {
@@ -2104,6 +2307,10 @@ class MERGER extends UTIL
                             $tmp_service = "[".$tmp_DG_name."] - ".$pickedObject->name()." {new}";
 
                         $countChildCreated++;
+                    }
+                    elseif( $tmp_service == null )
+                    {
+                        continue;
                     }
                     else
                     {
@@ -2152,6 +2359,17 @@ class MERGER extends UTIL
                     // Merging loop finally!
                     foreach( $hash as $objectIndex => $object )
                     {
+                        if( $tmp_service === null )
+                            continue;
+
+                        if( $this->dupAlg == 'identical' )
+                            if( $object->name() != $tmp_service->name() )
+                            {
+                                PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$tmp_service->_PANC_shortName()}'");
+                                $this->skippedObject( $index, $tmp_service, $object);
+                                continue;
+                            }
+
                         $skipped = $this->servicePickedObjectValidation( $index, $object, $tmp_service );
                         if( $skipped )
                             continue;
@@ -2176,6 +2394,10 @@ class MERGER extends UTIL
                         $countChildRemoved++;
                     }
                 }
+
+                if( count( $child_hashMap ) >0 )
+                    PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServices()}' (removed/created {$countChildRemoved}/{$countChildCreated} services)\n" );
+
 
                 foreach( $hashMap as $index => &$hash )
                 {
@@ -2209,6 +2431,14 @@ class MERGER extends UTIL
                                     $skipped = $this->servicePickedObjectValidation( $index, $object, $ancestor );
                                     if( $skipped )
                                         continue;
+
+                                    if( $this->dupAlg == 'identical' )
+                                        if( $object->name() != $ancestor->name() )
+                                        {
+                                            PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$ancestor->_PANC_shortName()}'");
+                                            $this->skippedObject( $index, $ancestor, $object);
+                                            continue;
+                                        }
 
                                     $text = "    - object '{$object->name()}' merged with its ancestor, deleting: ".$object->_PANC_shortName();
                                     if( $this->action === "merge" )
@@ -2261,6 +2491,13 @@ class MERGER extends UTIL
                         if( $object === $pickedObject )
                             continue;
 
+                        if( $this->dupAlg == 'identical' )
+                            if( $object->name() != $pickedObject->name() )
+                            {
+                                PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' is not IDENTICAL to object name from upperlevel '{$pickedObject->_PANC_shortName()}'");
+                                $this->skippedObject( $index, $pickedObject, $object);
+                                continue;
+                            }
 
                         PH::print_stdout("    - replacing '{$object->_PANC_shortName()}' ...");
                         if( $this->action === "merge" )
@@ -2392,8 +2629,7 @@ class MERGER extends UTIL
 
 
             PH::print_stdout( "\n\nDuplicates removal is now done. Number of objects after cleanup: '{$store->countServices()}' (removed {$countRemoved} services)\n" );
-            if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServices()}' (removed/created {$countChildRemoved}/{$countChildCreated} services)\n" );
+
         }
     }
 
@@ -2423,21 +2659,12 @@ class MERGER extends UTIL
     {
         foreach( $this->location_array as $tmp_location )
         {
-            $store = $tmp_location['store'];
-            $findLocation = $tmp_location['findLocation'];
-            $parentStore = $tmp_location['parentStore'];
-            $childDeviceGroups = $tmp_location['childDeviceGroups'];
+            $store = null;
+            $findLocation = null;
+            $parentStore = null;
+            $childDeviceGroups = null;
+            $this->locationSettings( $tmp_location, "Tag", $store,$findLocation,$parentStore,$childDeviceGroups);
 
-            PH::print_stdout( "\n\n***********************************************\n" );
-            PH::print_stdout( " - upper level search status : " . boolYesNo($this->upperLevelSearch) . "" );
-            if( is_string($findLocation) )
-                PH::print_stdout( " - location 'shared' found" );
-            else
-                PH::print_stdout( " - location '{$findLocation->name()}' found" );
-            PH::print_stdout( " - found {$store->count()} tag Objects" );
-            PH::print_stdout( " - DupAlgorithm selected: {$this->dupAlg}" );
-            PH::print_stdout( " - computing tag values database ... " );
-            sleep(1);
 
             //
             // Building a hash table of all tag objects with same value
@@ -2972,18 +3199,27 @@ class MERGER extends UTIL
             $this->skippedObjects[$index]['kept'] = "[".$tmpDG. "] - ".$keptOBJ->name();
             if( get_class( $removedOBJ ) === "Address" )
             {
-                /** @var $keptOBJ Address */
-                $this->skippedObjects[$index]['kept'] .= "{value:".$keptOBJ->value()."}";
+                if( get_class( $keptOBJ ) === "Address" )
+                {
+                    /** @var $keptOBJ Address */
+                    $this->skippedObjects[$index]['kept'] .= "{value:".$keptOBJ->value()."}";
+                }
+                else
+                    $this->skippedObjects[$index]['kept'] .= "{value:GROUP}";
             }
             elseif( get_class( $removedOBJ ) === "Service" )
             {
-                /** @var $keptOBJ Service */
-                $this->skippedObjects[$index]['kept'] .= " {prot:".$keptOBJ->protocol()."}{dport:".$keptOBJ->getDestPort()."}";
-                if( !empty($keptOBJ->getSourcePort()) )
-                    $this->skippedObjects[$index]['kept'] .= "{sport:".$keptOBJ->getSourcePort()."}";
-                if( !empty($keptOBJ->getTimeout()) )
-                    $this->skippedObjects[$index]['kept'] .= "{timeout:".$keptOBJ->getTimeout()."}";
-
+                if( get_class( $keptOBJ ) === "Service" )
+                {
+                    /** @var $keptOBJ Service */
+                    $this->skippedObjects[$index]['kept'] .= " {prot:".$keptOBJ->protocol()."}{dport:".$keptOBJ->getDestPort()."}";
+                    if( !empty($keptOBJ->getSourcePort()) )
+                        $this->skippedObjects[$index]['kept'] .= "{sport:".$keptOBJ->getSourcePort()."}";
+                    if( !empty($keptOBJ->getTimeout()) )
+                        $this->skippedObjects[$index]['kept'] .= "{timeout:".$keptOBJ->getTimeout()."}";
+                }
+                else
+                    $this->skippedObjects[$index]['kept'] .= "{value:GROUP}";
             }
 
         }

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -863,7 +863,7 @@ class MERGER extends UTIL
                 }
             }
             if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddressGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} addressgroups)\n" );
+                PH::print_stdout( "\n\nDuplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddressGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} addressgroups)\n" );
 
 
             $countRemoved = 0;
@@ -988,7 +988,7 @@ class MERGER extends UTIL
 
                     if( $object === $pickedObject )
                     {
-                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                        #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
                     }
 
@@ -1368,7 +1368,7 @@ class MERGER extends UTIL
 
             }
             if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddresses()}' (removed/created {$countChildRemoved}/{$countChildCreated} addresses)\n" );
+                PH::print_stdout( "\n\nDuplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countAddresses()}' (removed/created {$countChildRemoved}/{$countChildCreated} addresses)\n" );
 
 
             $countRemoved = 0;
@@ -1477,7 +1477,7 @@ class MERGER extends UTIL
 
                     if( $object === $pickedObject )
                     {
-                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                        #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
                     }
 
@@ -1924,7 +1924,7 @@ class MERGER extends UTIL
                 }
             }
             if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServiceGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} servicegroups)\n" );
+                PH::print_stdout( "\n\nDuplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServiceGroups()}' (removed/created {$countChildRemoved}/{$countChildCreated} servicegroups)\n" );
 
 
 
@@ -2050,7 +2050,7 @@ class MERGER extends UTIL
 
                     if( $object === $pickedObject )
                     {
-                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                        #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
                     }
 
@@ -2411,7 +2411,7 @@ class MERGER extends UTIL
                 }
 
                 if( count( $child_hashMap ) >0 )
-                    PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServices()}' (removed/created {$countChildRemoved}/{$countChildCreated} services)\n" );
+                    PH::print_stdout( "\n\nDuplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->countServices()}' (removed/created {$countChildRemoved}/{$countChildCreated} services)\n" );
 
 
                 foreach( $hashMap as $index => &$hash )
@@ -2505,7 +2505,7 @@ class MERGER extends UTIL
 
                         if( $object === $pickedObject )
                         {
-                            PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                            #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                             continue;
                         }
 
@@ -2586,7 +2586,7 @@ class MERGER extends UTIL
 
                         if( $object === $pickedObject )
                         {
-                            PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                            #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                             continue;
                         }
 
@@ -2899,6 +2899,9 @@ class MERGER extends UTIL
                 }
             }
 
+            if( count( $child_hashMap ) >0 )
+                PH::print_stdout( "\n\nDuplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->count()}' (removed/created {$countChildRemoved}/{$countChildCreated} tags)\n" );
+
             $countRemoved = 0;
             foreach( $hashMap as $index => &$hash )
             {
@@ -2994,7 +2997,7 @@ class MERGER extends UTIL
 
                     if( $object === $pickedObject )
                     {
-                        PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
+                        #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");
                         continue;
                     }
 
@@ -3031,8 +3034,6 @@ class MERGER extends UTIL
             }
 
             PH::print_stdout( "\n\nDuplicates removal is now done. Number of objects after cleanup: '{$store->count()}' (removed {$countRemoved} tags)\n" );
-            if( count( $child_hashMap ) >0 )
-                PH::print_stdout( "Duplicates ChildDG removal is now done. Number of objects after cleanup: '{$store->count()}' (removed/created {$countChildRemoved}/{$countChildCreated} tags)\n" );
 
         }
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
UTIL:
* type=addressgroup-/servicegroup-/service-merger | introduce dupalgorithm=identical
* type=servicegroup-merger | introduce childDG validation
* type=addressgroup-/servicegroup-/merger - for childDG object move; correct hashmap object array of actual DG

BUGFIX:
* type=diff "filter=XPATH" | bugfix as filter was not used
* type=UTIL-merger | fix for Buckbeak validation

GENERAL:
* extend different Fawkes and Buckbeak related classes
* improve bash completion script
* class TemplateStack | introduce method setName()
* class PanoramaConf | introduce method removeTemplateStack - improve removeDeviceGroup and removeTemplate
* class MERGER | method servicegroup_merger - correct variable name
* test script optimisation - MERGER output adjustment