### PR TITLE
introduce version 2.0.57

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.0.57
 UTIL:
+* type=rule | introduce new 'filter=(uuid eq 1234567890)'
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=rule | introduce new 'filter=(uuid eq 1234567890)'
 * type=rule | introduce 'actions=name-rename:$$current.name$$-$$uuid$$'
+* type=stats | improvement to get exportcsv=file.csv working for argument location
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63
+* type=address actions=value-host-object-add-netmask-m32 | skip if IPv6 address
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ BUGFIX:
 * type=playbook | skip creating out file for usage of html-merger
 * type=address | improvement for ipv6 if 'actions=name-rename:host.pub_$$value.no-netmask$$-$$netmask$$'
 * type=address-merger | bugfix for fqdn objects with different value but same name spread of DG hierarchy
+* type=ALL | argument location=DGname:includeChildDgs - bugfix if DG is not found
 
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ BUGFIX:
 
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup
+* update git-php
 
 
 2.0.56 (20220829)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTIL:
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63
 * type=address actions=value-host-object-add-netmask-m32 | skip if IPv6 address
+* type=playbook | skip creating out file for usage of html-merger
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=playbook | skip creating out file for usage of html-merger
 
 GENERAL:
+* class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup
 
 
 2.0.56 (20220829)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ BUGFIX:
 * type=address | improvement for ipv6 if 'actions=name-rename:host.pub_$$value.no-netmask$$-$$netmask$$'
 * type=address-merger | bugfix for fqdn objects with different value but same name spread of DG hierarchy
 * type=ALL | argument location=DGname:includeChildDgs - bugfix if DG is not found
+* type=rule | bugfix for 'filter=(schedule is.expired)'
 
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,15 @@
 CHANGELOG
 
-2.0.56
+2.0.57
+UTIL:
+
+BUGFIX:
+* type=address/service | fix for actions=name-rename - to skip if string length > 63
+
+GENERAL:
+
+
+2.0.56 (20220829)
 UTIL:
 * type=stats - improvement for JSON output
 * type=zone | introduce actions=display userid information | 'filter=(userid is.enbaled)'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ BUGFIX:
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup
 * update git-php
+* class AddressStore - revert group loop check
 
 
 2.0.56 (20220829)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=rule | introduce new 'filter=(uuid eq 1234567890)'
 * type=rule | introduce 'actions=name-rename:$$current.name$$-$$uuid$$'
 * type=stats | improvement to get exportcsv=file.csv working for argument location
+* type=ALL - introduce optional argument for location=DGname:includeChildDgs / location=DGname:excludeMainDg
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=address actions=value-host-object-add-netmask-m32 | skip if IPv6 address
 * type=playbook | skip creating out file for usage of html-merger
 * type=address | improvement for ipv6 if 'actions=name-rename:host.pub_$$value.no-netmask$$-$$netmask$$'
+* type=address-merger | bugfix for fqdn objects with different value but same name spread of DG hierarchy
 
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 * type=rule | introduce 'actions=name-rename:$$current.name$$-$$uuid$$'
 * type=stats | improvement to get exportcsv=file.csv working for argument location
 * type=ALL - introduce optional argument for location=DGname:includeChildDgs / location=DGname:excludeMainDg
+* type=ALL - introduce again argument shadow-apikeyhidden
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63
 * type=address actions=value-host-object-add-netmask-m32 | skip if IPv6 address
 * type=playbook | skip creating out file for usage of html-merger
+* type=address | improvement for ipv6 if 'actions=name-rename:host.pub_$$value.no-netmask$$-$$netmask$$'
 
 GENERAL:
 * class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.0.57
 UTIL:
 * type=rule | introduce new 'filter=(uuid eq 1234567890)'
+* type=rule | introduce 'actions=name-rename:$$current.name$$-$$uuid$$'
 
 BUGFIX:
 * type=address/service | fix for actions=name-rename - to skip if string length > 63

--- a/git-php/.gitignore
+++ b/git-php/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/tests/tmp/
+/composer.lock
+.idea
+**/.DS_Store

--- a/git-php/readme.md
+++ b/git-php/readme.md
@@ -206,12 +206,12 @@ $repo->pull('origin');
 // pushs changes to remote
 $repo->push('remote-name', ['--options']);
 $repo->push('origin');
-$repo->push('origin', ['master', '-u']);
+$repo->push(['origin', 'master'], ['-u']);
 
 // fetchs changes from remote
 $repo->fetch('remote-name', ['--options']);
 $repo->fetch('origin');
-$repo->fetch('origin', ['master']);
+$repo->fetch(['origin', 'master']);
 
 // adds remote repository
 $repo->addRemote('remote-name', 'repository-url', ['--options']);

--- a/git-php/src/Git.php
+++ b/git-php/src/Git.php
@@ -47,6 +47,7 @@
 				$this->run($directory, [
 					'init',
 					$params,
+					'--end-of-options',
 					$directory
 				]);
 
@@ -90,6 +91,7 @@
 				$this->run($cwd, [
 					'clone',
 					$params,
+					'--end-of-options',
 					$url,
 					$directory
 				]);
@@ -121,6 +123,7 @@
 				'--heads',
 				'--quiet',
 				'--exit-code',
+				'--end-of-options',
 				$url,
 				$refs,
 			], [

--- a/git-php/src/GitRepository.php
+++ b/git-php/src/GitRepository.php
@@ -352,7 +352,13 @@
 		public function commit($message, $options = NULL)
 		{
             if( $this->hasChanges() )
-	
+            {
+                /*
+                $this->run('commit', $params, [
+                    '-m' => $message,
+                ]);
+                */
+            }
             else
                 print "nothing to commit, working tree clean\n";
 

--- a/git-php/src/GitRepository.php
+++ b/git-php/src/GitRepository.php
@@ -52,7 +52,7 @@
 		 */
 		public function createTag($name, $options = NULL)
 		{
-			$this->run('tag', $options, $name);
+			$this->run('tag', $options, '--end-of-options', $name);
 			return $this;
 		}
 
@@ -86,7 +86,7 @@
 		{
 			// http://stackoverflow.com/a/1873932
 			// create new as alias to old (`git tag NEW OLD`)
-			$this->run('tag', $newName, $oldName);
+			$this->run('tag', '--end-of-options', $newName, $oldName);
 			// delete old (`git tag -d OLD`)
 			$this->removeTag($oldName);
 			return $this;
@@ -114,7 +114,7 @@
 		 */
 		public function merge($branch, $options = NULL)
 		{
-			$this->run('merge', $options, $branch);
+			$this->run('merge', $options, '--end-of-options', $branch);
 			return $this;
 		}
 
@@ -133,7 +133,7 @@
             if( !in_array ( $name, $this->getBranches()) )
             {
                 // git branch $name
-                $this->run('branch', $name);
+				$this->run('branch', '--end-of-options', $name);
             }
 
 			if ($checkout) {
@@ -237,6 +237,18 @@
 		 */
 		public function checkout($name)
 		{
+			if (!is_string($name)) {
+				throw new InvalidArgumentException('Branch name must be string.');
+			}
+
+			if ($name === '') {
+				throw new InvalidArgumentException('Branch name cannot be empty.');
+			}
+
+			if ($name[0] === '-') {
+				throw new InvalidArgumentException('Branch name cannot be option name.');
+			}
+
 			$this->run('checkout', $name);
 			return $this;
 		}
@@ -256,7 +268,7 @@
 			}
 
 			foreach ($file as $item) {
-				$this->run('rm', $item, '-r');
+				$this->run('rm', '-r', '--end-of-options', $item);
 			}
 
 			return $this;
@@ -285,7 +297,7 @@
 					throw new GitException("The path at '$item' does not represent a valid file.");
 				}
 
-				$this->run('add', $item);
+				$this->run('add', '--end-of-options', $item);
 			}
 
 			return $this;
@@ -322,7 +334,7 @@
 			}
 
 			foreach ($file as $from => $to) {
-				$this->run('mv', $from, $to);
+				$this->run('mv', '--end-of-options', $from, $to);
 			}
 
 			return $this;
@@ -333,16 +345,14 @@
 		 * Commits changes
 		 * `git commit <params> -m <message>`
 		 * @param  string $message
-		 * @param  string[] $params  param => value
+		 * @param  array<mixed>|NULL $options
 		 * @throws GitException
 		 * @return static
 		 */
-		public function commit($message, $params = NULL)
+		public function commit($message, $options = NULL)
 		{
             if( $this->hasChanges() )
-			    $this->run('commit', $params, [
-                    '-m' => $message,
-                ]);
+	
             else
                 print "nothing to commit, working tree clean\n";
 
@@ -358,7 +368,7 @@
 		 */
 		public function getLastCommitId()
 		{
-			$result = $this->run('log', '--pretty=format:"%H"', '-n', '1');
+			$result = $this->run('log', '--pretty=format:%H', '-n', '1');
 			$lastLine = $result->getOutputLastLine();
 			return new CommitId((string) $lastLine);
 		}
@@ -384,24 +394,26 @@
 			}
 
 			// subject
-			$result = $this->run('log', '-1', $commitId, '--format="%s"');
+			$result = $this->run('log', '-1', $commitId, '--format=%s');
 			$subject = rtrim($result->getOutputAsString());
 
 			// body
-			$result = $this->run('log', '-1', $commitId, '--format="%b"');
+			$result = $this->run('log', '-1', $commitId, '--format=%b');
 			$body = rtrim($result->getOutputAsString());
 
 			// author email
-			$result = $this->run('log', '-1', $commitId, '--format="%ae"');
+			$result = $this->run('log', '-1', $commitId, '--format=%ae');
 			$authorEmail = rtrim($result->getOutputAsString());
 
 			// author name
-			$result = $this->run('log', '-1', $commitId, '--format="%an"');
+			$result = $this->run('log', '-1', $commitId, '--format=%an');
 			$authorName = rtrim($result->getOutputAsString());
 
 			// author date
-			#$result = $this->run('log', '-1', $commitId, '--pretty="format:%ad"', '--date=iso-strict');
+
+			#$result = $this->run('log', '-1', $commitId, '--pretty=format:%ad', '--date=iso-strict');
             $result = $this->run('log', '-1', $commitId, '--pretty="%ad"', '--date=iso-strict');
+
 			$authorDate = \DateTimeImmutable::createFromFormat(\DateTime::ATOM, (string) $result->getOutputLastLine());
 
 
@@ -410,16 +422,18 @@
 			}
 
 			// committer email
-			$result = $this->run('log', '-1', $commitId, '--format="%ce"');
+			$result = $this->run('log', '-1', $commitId, '--format=%ce');
 			$committerEmail = rtrim($result->getOutputAsString());
 
 			// committer name
-			$result = $this->run('log', '-1', $commitId, '--format="%cn"');
+			$result = $this->run('log', '-1', $commitId, '--format=%cn');
 			$committerName = rtrim($result->getOutputAsString());
 
 			// committer date
-			#$result = $this->run('log', '-1', $commitId, '--pretty="format:%cd"', '--date=iso-strict');
+			#$result = $this->run('log', '-1', $commitId, '--pretty=format:%cd', '--date=iso-strict');
             $result = $this->run('log', '-1', $commitId, '--pretty="%ad"', '--date=iso-strict');
+
+
 			$committerDate = \DateTimeImmutable::createFromFormat(\DateTime::ATOM, (string) $result->getOutputLastLine());
 
 			if (!($committerDate instanceof \DateTimeImmutable)) {
@@ -457,42 +471,42 @@
 
 		/**
 		 * Pull changes from a remote
-		 * @param  string|NULL $remote
-		 * @param  array<mixed>|NULL $params
+		 * @param  string|string[]|NULL $remote
+		 * @param  array<mixed>|NULL $options
 		 * @return static
 		 * @throws GitException
 		 */
-		public function pull($remote = NULL, array $params = NULL)
+		public function pull($remote = NULL, array $options = NULL)
 		{
-			$this->run('pull', $remote, $params);
+			$this->run('pull', $options, '--end-of-options', $remote);
 			return $this;
 		}
 
 
 		/**
 		 * Push changes to a remote
-		 * @param  string|NULL $remote
-		 * @param  array<mixed>|NULL $params
+		 * @param  string|string[]|NULL $remote
+		 * @param  array<mixed>|NULL $options
 		 * @return static
 		 * @throws GitException
 		 */
-		public function push($remote = NULL, array $params = NULL)
+		public function push($remote = NULL, array $options = NULL)
 		{
-			$this->run('push', $remote, $params);
+			$this->run('push', $options, '--end-of-options', $remote);
 			return $this;
 		}
 
 
 		/**
 		 * Run fetch command to get latest branches
-		 * @param  string|NULL $remote
-		 * @param  array<mixed>|NULL $params
+		 * @param  string|string[]|NULL $remote
+		 * @param  array<mixed>|NULL $options
 		 * @return static
 		 * @throws GitException
 		 */
-		public function fetch($remote = NULL, array $params = NULL)
+		public function fetch($remote = NULL, array $options = NULL)
 		{
-			$this->run('fetch', $remote, $params);
+			$this->run('fetch', $options, '--end-of-options', $remote);
 			return $this;
 		}
 
@@ -501,13 +515,13 @@
 		 * Adds new remote repository
 		 * @param  string $name
 		 * @param  string $url
-		 * @param  array<mixed>|NULL $params
+		 * @param  array<mixed>|NULL $options
 		 * @return static
 		 * @throws GitException
 		 */
-		public function addRemote($name, $url, array $params = NULL)
+		public function addRemote($name, $url, array $options = NULL)
 		{
-			$this->run('remote', 'add', $params, $name, $url);
+			$this->run('remote', 'add', $options, '--end-of-options', $name, $url);
 			return $this;
 		}
 
@@ -521,7 +535,7 @@
 		 */
 		public function renameRemote($oldName, $newName)
 		{
-			$this->run('remote', 'rename', $oldName, $newName);
+			$this->run('remote', 'rename', '--end-of-options', $oldName, $newName);
 			return $this;
 		}
 
@@ -534,7 +548,7 @@
 		 */
 		public function removeRemote($name)
 		{
-			$this->run('remote', 'remove', $name);
+			$this->run('remote', 'remove', '--end-of-options', $name);
 			return $this;
 		}
 
@@ -543,13 +557,13 @@
 		 * Changes remote repository URL
 		 * @param  string $name
 		 * @param  string $url
-		 * @param  array<mixed>|NULL $params
+		 * @param  array<mixed>|NULL $options
 		 * @return static
 		 * @throws GitException
 		 */
-		public function setRemoteUrl($name, $url, array $params = NULL)
+		public function setRemoteUrl($name, $url, array $options = NULL)
 		{
-			$this->run('remote', 'set-url', $params, $name, $url);
+			$this->run('remote', 'set-url', $options, '--end-of-options', $name, $url);
 			return $this;
 		}
 

--- a/git-php/tests/GitPhp/GitRepository.branches.phpt
+++ b/git-php/tests/GitPhp/GitRepository.branches.phpt
@@ -10,10 +10,10 @@ require __DIR__ . '/bootstrap.php';
 $runner = new AssertRunner(__DIR__);
 $git = new Git($runner);
 
-$runner->assert(['branch', 'master']);
-$runner->assert(['branch', 'develop']);
+$runner->assert(['branch', '--end-of-options', 'master']);
+$runner->assert(['branch', '--end-of-options', 'develop']);
 $runner->assert(['checkout', 'develop']);
-$runner->assert(['merge', 'feature-1']);
+$runner->assert(['merge', '--end-of-options', 'feature-1']);
 $runner->assert(['branch', '-d', 'feature-1']);
 $runner->assert(['checkout', 'master']);
 

--- a/git-php/tests/GitPhp/GitRepository.files.phpt
+++ b/git-php/tests/GitPhp/GitRepository.files.phpt
@@ -14,11 +14,11 @@ $repo = $git->open(__DIR__ . '/fixtures');
 
 test(function () use ($repo, $runner) {
 	$runner->resetAsserts();
-	$runner->assert(['add', 'file1.txt']);
-	$runner->assert(['add', 'file2.txt']);
-	$runner->assert(['add', 'file3.txt']);
-	$runner->assert(['add', 'file4.txt']);
-	$runner->assert(['add', 'file5.txt']);
+	$runner->assert(['add', '--end-of-options', 'file1.txt']);
+	$runner->assert(['add', '--end-of-options', 'file2.txt']);
+	$runner->assert(['add', '--end-of-options', 'file3.txt']);
+	$runner->assert(['add', '--end-of-options', 'file4.txt']);
+	$runner->assert(['add', '--end-of-options', 'file5.txt']);
 
 	$repo->addFile('file1.txt');
 	$repo->addFile([
@@ -38,11 +38,11 @@ test(function () use ($repo) {
 
 test(function () use ($repo, $runner) {
 	$runner->resetAsserts();
-	$runner->assert(['rm', 'file1.txt', '-r']);
-	$runner->assert(['rm', 'file2.txt', '-r']);
-	$runner->assert(['rm', 'file3.txt', '-r']);
-	$runner->assert(['rm', 'file4.txt', '-r']);
-	$runner->assert(['rm', 'file5.txt', '-r']);
+	$runner->assert(['rm', '-r', '--end-of-options', 'file1.txt']);
+	$runner->assert(['rm', '-r', '--end-of-options', 'file2.txt']);
+	$runner->assert(['rm', '-r', '--end-of-options', 'file3.txt']);
+	$runner->assert(['rm', '-r', '--end-of-options', 'file4.txt']);
+	$runner->assert(['rm', '-r', '--end-of-options', 'file5.txt']);
 
 	$repo->removeFile('file1.txt');
 	$repo->removeFile([
@@ -55,9 +55,9 @@ test(function () use ($repo, $runner) {
 
 test(function () use ($repo, $runner) {
 	$runner->resetAsserts();
-	$runner->assert(['mv', 'file1.txt', 'new1.txt']);
-	$runner->assert(['mv', 'file2.txt', 'new2.txt']);
-	$runner->assert(['mv', 'file3.txt', 'new3.txt']);
+	$runner->assert(['mv', '--end-of-options', 'file1.txt', 'new1.txt']);
+	$runner->assert(['mv', '--end-of-options', 'file2.txt', 'new2.txt']);
+	$runner->assert(['mv', '--end-of-options', 'file3.txt', 'new3.txt']);
 
 	$repo->renameFile('file1.txt', 'new1.txt');
 	$repo->renameFile([

--- a/git-php/tests/GitPhp/GitRepository.getCommit.phpt
+++ b/git-php/tests/GitPhp/GitRepository.getCommit.phpt
@@ -12,63 +12,63 @@ test(function () {
 
 	// last commit ID
 	$runner->assert(
-		['log', '--pretty=format:"%H"', '-n', '1'],
+		['log', '--pretty=format:%H', '-n', '1'],
 		[],
 		['734713bc047d87bf7eac9674765ae793478c50d3']
 	);
 
 	// commit subject
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%s"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%s'],
 		[],
 		['init commit', '', '']
 	);
 
 	// commit body
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%b"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%b'],
 		[],
 		['', '', ''] // 3 empty lines
 	);
 
 	// author email
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%ae"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%ae'],
 		[],
 		['john@example.com']
 	);
 
 	// author name
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%an"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%an'],
 		[],
 		['John Example']
 	);
 
 	// author date
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty="format:%ad"', '--date=iso-strict'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty=format:%ad', '--date=iso-strict'],
 		[],
 		["2021-04-29T15:55:09+00:00"]
 	);
 
 	// committer email
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%ce"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%ce'],
 		[],
 		["john@committer.com"]
 	);
 
 	// committer name
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%cn"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%cn'],
 		[],
 		["John Committer"]
 	);
 
 	// committter date
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty="format:%cd"', '--date=iso-strict'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty=format:%cd', '--date=iso-strict'],
 		[],
 		['2021-04-29T17:55:09+02:00']
 	);
@@ -98,56 +98,56 @@ test(function () {
 
 	// commit subject
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%s"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%s'],
 		[],
 		['init commit', '', '']
 	);
 
 	// commit body
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%b"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%b'],
 		[],
 		['first line', 'second line', '', ''] // + 2 empty lines
 	);
 
 	// author email
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%ae"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%ae'],
 		[],
 		['john@example.com']
 	);
 
 	// author name
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%an"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%an'],
 		[],
 		['John Example']
 	);
 
 	// author date
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty="format:%ad"', '--date=iso-strict'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty=format:%ad', '--date=iso-strict'],
 		[],
 		["2021-04-29T15:55:09+00:00"]
 	);
 
 	// committer email
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%ce"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%ce'],
 		[],
 		["john@committer.com"]
 	);
 
 	// committer name
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format="%cn"'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--format=%cn'],
 		[],
 		["John Committer"]
 	);
 
 	// committter date
 	$runner->assert(
-		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty="format:%cd"', '--date=iso-strict'],
+		['log', '-1', '734713bc047d87bf7eac9674765ae793478c50d3', '--pretty=format:%cd', '--date=iso-strict'],
 		[],
 		['2021-04-29T17:55:09+02:00']
 	);

--- a/git-php/tests/GitPhp/GitRepository.getLastCommitId.phpt
+++ b/git-php/tests/GitPhp/GitRepository.getLastCommitId.phpt
@@ -10,7 +10,7 @@ $runner = new AssertRunner(__DIR__);
 $git = new Git($runner);
 
 $runner->assert(
-	['log', '--pretty=format:"%H"', '-n', '1'],
+	['log', '--pretty=format:%H', '-n', '1'],
 	[],
 	['734713bc047d87bf7eac9674765ae793478c50d3']
 );

--- a/git-php/tests/GitPhp/GitRepository.remotes.phpt
+++ b/git-php/tests/GitPhp/GitRepository.remotes.phpt
@@ -10,17 +10,17 @@ require __DIR__ . '/bootstrap.php';
 $runner = new AssertRunner(__DIR__);
 $git = new Git($runner);
 
-$runner->assert(['clone', '-q', 'git@github.com:czproject/git-php.git', __DIR__]);
-$runner->assert(['remote', 'add', 'origin2', 'git@github.com:czproject/git-php.git']);
-$runner->assert(['remote', 'add', 'remote', 'git@github.com:czproject/git-php.git']);
+$runner->assert(['clone', '-q', '--end-of-options', 'git@github.com:czproject/git-php.git', __DIR__]);
+$runner->assert(['remote', 'add', '--end-of-options', 'origin2', 'git@github.com:czproject/git-php.git']);
+$runner->assert(['remote', 'add', '--end-of-options', 'remote', 'git@github.com:czproject/git-php.git']);
 $runner->assert(['remote', 'add', [
 	'--mirror=push',
-], 'only-push', 'test-url']);
-$runner->assert(['remote', 'rename', 'remote', 'origin3']);
+], '--end-of-options', 'only-push', 'test-url']);
+$runner->assert(['remote', 'rename', '--end-of-options', 'remote', 'origin3']);
 $runner->assert(['remote', 'set-url', [
 	'--push',
-], 'origin3', 'test-url']);
-$runner->assert(['remote', 'remove', 'origin2']);
+], '--end-of-options', 'origin3', 'test-url']);
+$runner->assert(['remote', 'remove', '--end-of-options', 'origin2']);
 
 $repo = $git->cloneRepository('git@github.com:czproject/git-php.git', __DIR__);
 $repo->addRemote('origin2', 'git@github.com:czproject/git-php.git');
@@ -34,9 +34,17 @@ $repo->setRemoteUrl('origin3', 'test-url', [
 ]);
 $repo->removeRemote('origin2');
 
-$runner->assert(['push', 'origin']);
-$runner->assert(['fetch', 'origin']);
-$runner->assert(['pull', 'origin']);
+$runner->assert(['push', '--end-of-options', 'origin']);
+$runner->assert(['push', '--repo', 'https://user:password@example.com/MyUser/MyRepo.git', '--end-of-options']);
+$runner->assert(['push', '--end-of-options', 'origin', 'master']);
+$runner->assert(['fetch', '--end-of-options', 'origin']);
+$runner->assert(['fetch', '--end-of-options', 'origin', 'master']);
+$runner->assert(['pull', '--end-of-options', 'origin']);
+$runner->assert(['pull', '--end-of-options', 'origin', 'master']);
 $repo->push('origin');
+$repo->push(NULL, ['--repo' => 'https://user:password@example.com/MyUser/MyRepo.git']);
+$repo->push(['origin', 'master']);
 $repo->fetch('origin');
+$repo->fetch(['origin', 'master']);
 $repo->pull('origin');
+$repo->pull(['origin', 'master']);

--- a/git-php/tests/GitPhp/GitRepository.tags.phpt
+++ b/git-php/tests/GitPhp/GitRepository.tags.phpt
@@ -10,8 +10,8 @@ require __DIR__ . '/bootstrap.php';
 $runner = new AssertRunner(__DIR__);
 $git = new Git($runner);
 
-$runner->assert(['tag', 'v1.0.0']);
-$runner->assert(['tag', 'v2.0.0', 'v1.0.0']);
+$runner->assert(['tag', '--end-of-options', 'v1.0.0']);
+$runner->assert(['tag', '--end-of-options', 'v2.0.0', 'v1.0.0']);
 $runner->assert(['tag', '-d', 'v1.0.0']);
 $runner->assert(['tag', '-d', 'v2.0.0']);
 

--- a/git-php/tests/GitPhp/bootstrap.php
+++ b/git-php/tests/GitPhp/bootstrap.php
@@ -8,5 +8,24 @@ Tester\Environment::setup();
 
 function test($cb)
 {
-	$cb();
+	try {
+		$cb();
+
+	} catch (CzProject\GitPhp\GitException $e) {
+		$result = $e->getRunnerResult();
+
+		if ($result !== NULL) {
+			echo $result->getCommand(), "\n";
+			echo 'EXIT CODE: ', $result->getExitCode(), "\n";
+			echo "--------------\n",
+				$result->getOutputAsString(), "\n";
+
+			if ($result->hasErrorOutput()) {
+				echo "--------------\n",
+					implode("\n", $result->getErrorOutput()), "\n";
+			}
+		}
+
+		throw $e;
+	}
 }

--- a/git-php/tests/libs/AssertRunner.php
+++ b/git-php/tests/libs/AssertRunner.php
@@ -61,7 +61,7 @@
 				throw new \CzProject\GitPhp\InvalidStateException("Missing assert for command '$cmd'");
 			}
 
-			\Tester\Assert::same($cmd, $result->getCommand());
+			\Tester\Assert::same($result->getCommand(), $cmd);
 			next($this->asserts);
 			return $result;
 		}

--- a/lib/device-and-system-classes/DeviceGroup.php
+++ b/lib/device-and-system-classes/DeviceGroup.php
@@ -871,6 +871,7 @@ class DeviceGroup
         $stdoutarray['address objects']['address'] = $this->addressStore->countAddresses();
         $stdoutarray['address objects']['group'] = $this->addressStore->countAddressGroups();
         $stdoutarray['address objects']['tmp'] = $this->addressStore->countTmpAddresses();
+        $stdoutarray['address objects']['region'] = $this->addressStore->countRegionObjects();
         $stdoutarray['address objects']['unused'] = $this->addressStore->countUnused();
 
         $stdoutarray['service objects'] = array();
@@ -886,17 +887,6 @@ class DeviceGroup
 
         $stdoutarray['securityProfileGroup objects'] = array();
         $stdoutarray['securityProfileGroup objects']['total'] = $this->securityProfileGroupStore->count();
-
-        /*
-        $stdoutarray['securityProfile objects'] = array();
-        $stdoutarray['securityProfile objects']['Anti-Spyware'] = $this->AntiSpywareProfileStore->count();
-        $stdoutarray['securityProfile objects']['Vulnerability'] = $this->VulnerabilityProfileStore->count();
-        $stdoutarray['securityProfile objects']['Antivirus'] = $this->AntiVirusProfileStore->count();
-        $stdoutarray['securityProfile objects']['Wildfire'] = $this->WildfireProfileStore->count();
-        $stdoutarray['securityProfile objects']['URL'] = $this->URLProfileStore->count();
-        $stdoutarray['securityProfile objects']['File-Blocking'] = $this->FileBlockingProfileStore->count();
-        $stdoutarray['securityProfile objects']['Decryption'] = $this->DecryptionProfileStore->count();
-        */
 
         $stdoutarray['Anti-Spyware objects'] = array();
         $stdoutarray['Anti-Spyware objects']['total'] = $this->AntiSpywareProfileStore->count();
@@ -919,7 +909,8 @@ class DeviceGroup
         #$stdoutarray['apps'] = $this->appStore->count();
 
 
-        PH::$JSON_TMP[$this->name] = $stdoutarray;
+        #PH::$JSON_TMP[$this->name] = $stdoutarray;
+        PH::$JSON_TMP[] = $stdoutarray;
 
         if( !PH::$shadow_json )
             PH::print_stdout( $stdoutarray, true );

--- a/lib/device-and-system-classes/PANConf.php
+++ b/lib/device-and-system-classes/PANConf.php
@@ -770,6 +770,7 @@ class PANConf
         $gnaddressGs = $this->addressStore->countAddressGroups();
         $gnaddressGsUnused = $this->addressStore->countUnusedAddressGroups();
         $gnTmpAddresses = $this->addressStore->countTmpAddresses();
+        $gnRegionAddresses = $this->addressStore->countRegionObjects();
 
         $numInterfaces = $this->network->ipsecTunnelStore->count() + $this->network->ethernetIfStore->count();
         $numSubInterfaces = $this->network->ethernetIfStore->countSubInterfaces();
@@ -803,6 +804,7 @@ class PANConf
             $gnaddressGs += $vsys->addressStore->countAddressGroups();
             $gnaddressGsUnused += $vsys->addressStore->countUnusedAddressGroups();
             $gnTmpAddresses += $vsys->addressStore->countTmpAddresses();
+            $gnRegionAddresses = $vsys->addressStore->countRegionObjects();
 
             $gTagCount += $vsys->tagStore->count();
             $gTagUnusedCount += $vsys->tagStore->countUnused();
@@ -830,6 +832,7 @@ class PANConf
                 $gnaddressGs += $vsys->parentDeviceGroup->addressStore->countAddressGroups();
                 $gnaddressGsUnused += $vsys->parentDeviceGroup->addressStore->countUnusedAddressGroups();
                 $gnTmpAddresses += $vsys->parentDeviceGroup->addressStore->countTmpAddresses();
+                $gnRegionAddresses += $vsys->parentDeviceGroup->addressStore->countRegionObjects();
 
                 $gTagCount += $vsys->parentDeviceGroup->tagStore->count();
                 $gTagUnusedCount += $vsys->parentDeviceGroup->tagStore->countUnused();
@@ -887,6 +890,9 @@ class PANConf
         $stdoutarray['temporary address objects']['shared'] = $this->addressStore->countAddresses();
         $stdoutarray['temporary address objects']['total VSYSs'] = $gnTmpAddresses;
 
+        $stdoutarray['region objects'] = array();
+        $stdoutarray['region objects']['shared'] = $this->addressStore->countRegionObjects();
+        $stdoutarray['region objects']['total VSYSs'] = $gnRegionAddresses;
 
         $stdoutarray['service objects'] = array();
         $stdoutarray['service objects']['shared'] = $this->serviceStore->countServices();
@@ -920,15 +926,13 @@ class PANConf
         $stdoutarray['sub-interfaces']['ethernet'] = $this->network->ethernetIfStore->countSubInterfaces();
 
 
-        $connector = findConnector( $this );
-        if( $connector == null )
-            PH::$JSON_TMP[] = $stdoutarray;
-        else
-            PH::$JSON_TMP[ $connector->info_serial ] = $stdoutarray;
+
+        PH::$JSON_TMP[] = $stdoutarray;
 
 
         if( !PH::$shadow_json )
             PH::print_stdout( $stdoutarray, true );
+
 
 
     }

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -1225,6 +1225,7 @@ class PanoramaConf
         $gnaddressGs = $this->addressStore->countAddressGroups();
         $gnaddressGsUnused = $this->addressStore->countUnusedAddressGroups();
         $gnTmpAddresses = $this->addressStore->countTmpAddresses();
+        $gnRegionAddresses = $this->addressStore->countRegionObjects();
 
         $gTagCount = $this->tagStore->count();
         $gTagUnusedCount = $this->tagStore->countUnused();
@@ -1273,6 +1274,7 @@ class PanoramaConf
             $gnaddressGs += $cur->addressStore->countAddressGroups();
             $gnaddressGsUnused += $cur->addressStore->countUnusedAddressGroups();
             $gnTmpAddresses += $cur->addressStore->countTmpAddresses();
+            $gnRegionAddresses += $cur->addressStore->countRegionObjects();
 
             $gTagCount += $cur->tagStore->count();
             $gTagUnusedCount += $cur->tagStore->countUnused();
@@ -1393,6 +1395,9 @@ class PanoramaConf
         $stdoutarray['temporary address objects']['shared'] = $this->addressStore->countTmpAddresses();
         $stdoutarray['temporary address objects']['total_DGs'] = $gnTmpAddresses;
 
+        $stdoutarray['region objects'] = array();
+        $stdoutarray['region objects']['shared'] = $this->addressStore->countRegionObjects();
+        $stdoutarray['region objects']['total_DGs'] = $gnRegionAddresses;
 
         $stdoutarray['service objects'] = array();
         $stdoutarray['service objects']['shared'] = $this->serviceStore->countServices();
@@ -1457,12 +1462,97 @@ class PanoramaConf
         $stdoutarray['sub-interfaces']['ethernet'] = $this->network->ethernetIfStore->countSubInterfaces();
         */
 
+        #PH::$JSON_TMP['all'] = $stdoutarray;
+        PH::$JSON_TMP[] = $stdoutarray;
 
-        $connector = findConnector( $this );
-        if( $connector == null )
-            PH::$JSON_TMP[$this->name] = $stdoutarray;
-        else
-            PH::$JSON_TMP[ $connector->info_serial ] = $stdoutarray;
+        if( !PH::$shadow_json )
+            PH::print_stdout( $stdoutarray, true );
+
+        //-----------------
+        $stdoutarray = array();
+
+        $stdoutarray['type'] = get_class( $this );
+
+        $header = "Statistics for DG '" . PH::boldText('shared') . "'";
+        $stdoutarray['header'] = $header;
+
+        $stdoutarray['security rules'] = array();
+        $stdoutarray['security rules']['pre'] = $this->securityRules->countPreRules();
+        $stdoutarray['security rules']['post'] = $this->securityRules->countPostRules();
+
+        $stdoutarray['nat rules'] = array();
+        $stdoutarray['nat rules']['pre'] = $this->natRules->countPreRules();
+        $stdoutarray['nat rules']['post'] = $this->natRules->countPostRules();
+
+        $stdoutarray['qos rules'] = array();
+        $stdoutarray['qos rules']['pre'] = $this->qosRules->countPreRules();
+        $stdoutarray['qos rules']['post'] = $this->qosRules->countPostRules();
+
+        $stdoutarray['pbf rules'] = array();
+        $stdoutarray['pbf rules']['pre'] = $this->pbfRules->countPreRules();
+        $stdoutarray['pbf rules']['post'] = $this->pbfRules->countPostRules();
+
+        $stdoutarray['decrypt rules'] = array();
+        $stdoutarray['decrypt rules']['pre'] = $this->decryptionRules->countPreRules();
+        $stdoutarray['decrypt rules']['post'] = $this->decryptionRules->countPostRules();
+
+        $stdoutarray['app-override rules'] = array();
+        $stdoutarray['app-override rules']['pre'] = $this->appOverrideRules->countPreRules();
+        $stdoutarray['app-override rules']['post'] = $this->appOverrideRules->countPostRules();
+
+        $stdoutarray['captive-portal rules'] = array();
+        $stdoutarray['captive-portal rules']['pre'] = $this->captivePortalRules->countPreRules();
+        $stdoutarray['captive-portal rules']['post'] = $this->captivePortalRules->countPostRules();
+
+        $stdoutarray['authentication rules'] = array();
+        $stdoutarray['authentication rules']['pre'] = $this->authenticationRules->countPreRules();
+        $stdoutarray['authentication rules']['post'] = $this->authenticationRules->countPostRules();
+
+        $stdoutarray['dos rules'] = array();
+        $stdoutarray['dos rules']['pre'] = $this->dosRules->countPreRules();
+        $stdoutarray['dos rules']['post'] = $this->dosRules->countPostRules();
+
+        $stdoutarray['address objects'] = array();
+        $stdoutarray['address objects']['total'] = $this->addressStore->count();
+        $stdoutarray['address objects']['address'] = $this->addressStore->countAddresses();
+        $stdoutarray['address objects']['group'] = $this->addressStore->countAddressGroups();
+        $stdoutarray['address objects']['tmp'] = $this->addressStore->countTmpAddresses();
+        $stdoutarray['address objects']['region'] = $this->addressStore->countRegionObjects();
+        $stdoutarray['address objects']['unused'] = $this->addressStore->countUnused();
+
+        $stdoutarray['service objects'] = array();
+        $stdoutarray['service objects']['total'] = $this->serviceStore->count();
+        $stdoutarray['service objects']['service'] = $this->serviceStore->countServices();
+        $stdoutarray['service objects']['group'] = $this->serviceStore->countServiceGroups();
+        $stdoutarray['service objects']['tmp'] = $this->serviceStore->countTmpServices();
+        $stdoutarray['service objects']['unused'] = $this->serviceStore->countUnused();
+
+        $stdoutarray['tag objects'] = array();
+        $stdoutarray['tag objects']['total'] = $this->tagStore->count();
+        $stdoutarray['tag objects']['unused'] = $this->tagStore->countUnused();
+
+        $stdoutarray['securityProfileGroup objects'] = array();
+        $stdoutarray['securityProfileGroup objects']['total'] = $this->securityProfileGroupStore->count();
+
+        $stdoutarray['Anti-Spyware objects'] = array();
+        $stdoutarray['Anti-Spyware objects']['total'] = $this->AntiSpywareProfileStore->count();
+        $stdoutarray['Vulnerability objects'] = array();
+        $stdoutarray['Vulnerability objects']['total'] = $this->VulnerabilityProfileStore->count();
+        $stdoutarray['Antivirus objects'] = array();
+        $stdoutarray['Antivirus objects']['total'] = $this->AntiVirusProfileStore->count();
+        $stdoutarray['Wildfire objects'] = array();
+        $stdoutarray['Wildfire objects']['total'] = $this->WildfireProfileStore->count();
+        $stdoutarray['URL objects'] = array();
+        $stdoutarray['URL objects']['total'] = $this->URLProfileStore->count();
+        $stdoutarray['custom URL objects'] = array();
+        $stdoutarray['custom URL objects']['total'] = $this->customURLProfileStore->count();
+        $stdoutarray['File-Blocking objects'] = array();
+        $stdoutarray['File-Blocking objects']['total'] = $this->FileBlockingProfileStore->count();
+        $stdoutarray['Decryption objects'] = array();
+        $stdoutarray['Decryption objects']['total'] = $this->DecryptionProfileStore->count();
+
+        #PH::$JSON_TMP['shared'] = $stdoutarray;
+        PH::$JSON_TMP[] = $stdoutarray;
 
         if( !PH::$shadow_json )
             PH::print_stdout( $stdoutarray, true );

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -951,11 +951,15 @@ class PanoramaConf
                 if( count($dgLoadOrder) <= $dgLoadOrderCount )
                 {
                     PH::print_stdout(  "Problems could be available with the following DeviceGroup(s)" );
-                    print_r($dgLoadOrder);
-                    derr('dg-meta-data seems to be corrupted, parent.child template cannot be calculated ', $dgMetaDataNode);
+                    #print_r($dgLoadOrder);
+                    print_r($parentToDG);
+                    foreach( $parentToDG as $key => $dgName )
+                    {
+                        PH::print_stdout( "there is no DeviceGroup name: ".$key." available");
+                        $tmp = DH::findFirstElementByNameAttr( "entry", $dgName[0], $dgMetaDataNode );
+                        derr('dg-meta-data seems to be corrupted, parent.child template cannot be calculated ', $tmp, FALSE);
+                    }
                 }
-
-
             }
 
             /*PH::print_stdout(  "DG loading order:" );

--- a/lib/device-and-system-classes/VirtualSystem.php
+++ b/lib/device-and-system-classes/VirtualSystem.php
@@ -721,7 +721,8 @@ class VirtualSystem
         $stdoutarray['apps'] = $this->appStore->count();
 
 
-        PH::$JSON_TMP[$this->name] = $stdoutarray;
+        #PH::$JSON_TMP[$this->name] = $stdoutarray;
+        PH::$JSON_TMP[] = $stdoutarray;
 
 
         if( !PH::$shadow_json )

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -63,6 +63,14 @@ class PH
                     $argc--;
                 continue;
             }
+            elseif( $arg == 'shadow-apikeyhidden' )
+            {
+                PH::$sendAPIkeyviaHeader = TRUE;
+                unset(PH::$argv[$argIndex]);
+                if( !isset( $_SERVER['REQUEST_METHOD'] ) )
+                    $argc--;
+                continue;
+            }
             elseif( $arg == 'shadow-apikeynosave' )
             {
                 PH::$saveAPIkey = FALSE;

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -153,7 +153,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 0;
-    private static $library_version_bugfix = 56;
+    private static $library_version_bugfix = 57;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -201,6 +201,8 @@ RQuery::$defaultFilters['address']['object']['operators']['is.ipv6'] = Array(
                 $addr_value = $ip_range[0];
             }
 
+            if( $addr_value == null )
+                $addr_value = "";
             $ip_range = explode( "/", $addr_value );
             $addr_value = $ip_range[0];
 

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -3427,5 +3427,16 @@ RQuery::$defaultFilters['rule']['schedule.expire.in.days']['operators']['>,<,=,!
     },
     'arg' => true,
 );
+RQuery::$defaultFilters['rule']['uuid']['operators']['eq'] = array(
+    'Function' => function (RuleRQueryContext $context) {
+        return $context->object->uuid() == $context->value;
+    },
+    'arg' => TRUE,
+    'help' => 'returns TRUE if rule uuid matches the one specified in argument',
+    'ci' => array(
+        'fString' => '(%PROP%  1234567890)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 // </editor-fold>
 

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -549,7 +549,13 @@ class Address
         $explode = explode('/', $this->value);
 
         if( count($explode) < 2 )
-            return 32;
+        {
+            if(filter_var($this->value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+                return 128;
+            else
+                return 32;
+        }
+
 
         else
             return intval($explode[1]);
@@ -686,6 +692,11 @@ class Address
 
     public function replaceIPbyObject( $context, $prefix = array() )
     {
+        if(filter_var($this->value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+            $maxmaskvalue = 128;
+        else
+            $maxmaskvalue = 32;
+
         if( empty( $prefix ) )
         {
             $prefix['host'] = "H-";
@@ -727,10 +738,10 @@ class Address
             else
             {
                 $name = $this->name();
-                $mask = 32;
+                $mask = $maxmaskvalue;
             }
 
-            if( $mask > 32 || $mask < 0 )
+            if( $mask > $maxmaskvalue || $mask < 0 )
             {
                 $string = "because of invalid mask detected : '$mask'";
                 PH::ACTIONstatus( $context, "SKIPPED", $string );
@@ -744,7 +755,7 @@ class Address
                 return;
             }
 
-            if( $mask == 32 )
+            if( $mask == $maxmaskvalue )
             {
                 $newName = $prefix['host'] . $name;
             }

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -811,7 +811,7 @@ class AddressGroup
                 #if( isset( $ret[$serial] ) )
                 if( array_key_exists($serial, $grpArray) )
                 {
-                    mwarning("addressgroup with name: " . $object->name() . " is added as subgroup to servicegroup: " . $this->name() . ", you should review your XML config file", $object->xmlroot, false, false);
+                    mwarning("addressgroup with name: " . $object->name() . " is added as subgroup to addressgroup: " . $this->name() . ", you should review your XML config file", $object->xmlroot, false, false);
                     return $ret;
                 }
                 else

--- a/lib/object-classes/AddressStore.php
+++ b/lib/object-classes/AddressStore.php
@@ -873,6 +873,7 @@ class AddressStore
                             unset($tmpGroupDeps[$groupName]);
                     }
                 }
+                /*
                 elseif( count($groupDependencies) == 1 )
                 {
                     unset($sortingArray[$groupName]);
@@ -884,6 +885,7 @@ class AddressStore
                             unset($tmpGroupDeps[$groupName]);
                     }
                 }
+                */
             }
 
             $loopCount++;

--- a/lib/object-classes/Schedule.php
+++ b/lib/object-classes/Schedule.php
@@ -357,6 +357,7 @@ class Schedule
             return false;
 
         $d_actual = time();
+        $d = $d_actual;
         if( $futuredate !== 0 )
         {
             $d = $d_actual + ($futuredate)*24*3600;

--- a/utils/bash_autocompletion/pan-os-php.sh
+++ b/utils/bash_autocompletion/pan-os-php.sh
@@ -57,7 +57,7 @@ __pan-os-php_scripts()
 
 		arguments=('type=' 'in=' 'out=' 'actions=' 'filter=' 'location=' 'loadpanoramapushedconfig' 'loadplugin=' 'help'
 		 'listactions' 'listfilters' 'debugapi' 'apitimeout='
-		 'shadow-apikeynohidden' 'shadow-apikeynosave' 'shadow-disableoutputformatting' 'shadow-displaycurlrequest' 'shadow-enablexmlduplicatesdeletion'
+		 'shadow-apikeyhidden' 'shadow-apikeynohidden' 'shadow-apikeynosave' 'shadow-disableoutputformatting' 'shadow-displaycurlrequest' 'shadow-enablexmlduplicatesdeletion'
 		 'shadow-ignoreinvalidaddressobjects' 'shadow-json' 'shadow-reducexml'
 		 'outputformatset='
 		 'stats' 'template=' 'version' )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -2014,7 +2014,12 @@ AddressCallContext::$supportedActions[] = array(
             PH::ACTIONstatus( $context, "SKIPPED", $string );
             return;
         }
-
+        elseif( strpos( $value, ":") !== false )
+        {
+            $string = "object: " . $address->name() . " with value: " . $value . " is of type IPv6.";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
 
         //
         $new_value = $value . "/32";

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1057,6 +1057,7 @@ AddressCallContext::$supportedActions[] = array(
         if( strpos($newName, '$$value$$') !== FALSE )
         {
             $newName = str_replace('$$value$$', $object->value(), $newName);
+            $newName = str_replace(':', "_", $newName);
         }
         if( strpos($newName, '$$value.no-netmask$$') !== FALSE )
         {
@@ -1066,6 +1067,7 @@ AddressCallContext::$supportedActions[] = array(
                 $replace = $object->value();
 
             $newName = str_replace('$$value.no-netmask$$', $replace, $newName);
+            $newName = str_replace(':', "_", $newName);
         }
         if( strpos($newName, '$$netmask$$') !== FALSE )
         {
@@ -2021,8 +2023,10 @@ AddressCallContext::$supportedActions[] = array(
             return;
         }
 
-        //
-        $new_value = $value . "/32";
+        //if(filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+            //$new_value = $value . "/128";
+        //else
+            $new_value = $value . "/32";
 
         $text = $context->padding . " - new value will be: '" . $new_value . "'";
         if( $context->isAPI )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1131,6 +1131,14 @@ AddressCallContext::$supportedActions[] = array(
             return;
         }
 
+        $max_length = 63;
+        if( strlen($newName) > $max_length )
+        {
+            $string = "resulting name is too long";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         $string = "new name will be '{$newName}'";
         PH::ACTIONlog( $context, $string );
 

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -3142,6 +3142,9 @@ RuleCallContext::$supportedActions[] = array(
         if( strpos($newName, '$$current.name$$') !== FALSE )
             $newName = str_replace('$$current.name$$', $rule->name(), $newName);
 
+        if( strpos($newName, '$$uuid$$') !== FALSE )
+            $newName = str_replace('$$uuid$$', $rule->uuid(), $newName);
+
         if( strlen($newName) > 31 )
         {
             if( $context->object->owner->owner->version > 80 && strlen($newName) <= 63 && $context->arguments['accept63characters'] )
@@ -3191,7 +3194,8 @@ RuleCallContext::$supportedActions[] = array(
         'help' =>
             "This string is used to compose a name. You can use the following aliases :\n" .
             "  - \$\$current.name\$\$ : current name of the object\n" .
-            "  - \$\$sequential.number\$\$ : sequential number - starting with 1\n"
+            "  - \$\$sequential.number\$\$ : sequential number - starting with 1\n" .
+            "  - \$\$uuid\$\$ : rule uuid\n"
     ),
         'accept63characters' => array(
             'type' => 'bool',

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -984,6 +984,14 @@ ServiceCallContext::$supportedActions[] = array(
             return;
         }
 
+        $max_length = 63;
+        if( strlen($newName) > $max_length )
+        {
+            $string = "resulting name is too long";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         $string = "new name will be '{$newName}'";
         PH::ACTIONlog( $context, $string );
 

--- a/utils/lib/CONFIGSIZE.php
+++ b/utils/lib/CONFIGSIZE.php
@@ -124,7 +124,7 @@ class CONFIGSIZE extends UTIL
             PH::print_stdout( "The size of your original file is ".convert($filesize )." [100%]. It can be reduces to ".convert($len_xml_reduced)." [".$reduce_percent."%] (which is a reduction of ".convert($filesize-$len_xml_reduced)." [".(100-$reduce_percent)."%])");
         }
 
-        PH::print_stdout( PH::boldText( "Please be aware of that PAN-OS is automatically adding the xml overhead again during the next configuration load to the device" ) );
+        PH::print_stdout( PH::boldText( "Please be aware of that PAN-OS is automatically adding the xml overhead again during the configuration next configuration load [candidate-config] to the device" ) );
     }
 
     public function supportedArguments()

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1401,8 +1401,15 @@ class MERGER extends UTIL
                         #if( $this->upperLevelSearch && !$ancestor->isGroup() && !$ancestor->isTmpAddr() && ($ancestor->isType_ipNetmask() || $ancestor->isType_ipRange() || $ancestor->isType_FQDN()) )
                         if( $this->upperLevelSearch && !$ancestor->isGroup() && ($ancestor->isType_ipNetmask() || $ancestor->isType_ipRange() || $ancestor->isType_FQDN()) )
                         {
-                            if( $object->getIP4Mapping()->equals($ancestor->getIP4Mapping()) || ($object->isType_FQDN() && $ancestor->isType_FQDN()) && ($object->value() == $ancestor->value()) )
+                            if( $object->getIP4Mapping()->equals($ancestor->getIP4Mapping()) || ($object->isType_FQDN() && $ancestor->isType_FQDN()) && ($object->value() == $ancestor->value())  )
                             {
+                                if( $pickedObject->value() != $ancestor->value() )
+                                {
+                                    PH::print_stdout("    - SKIP: object name '{$ancestor->_PANC_shortName()}' [with value '{$ancestor->value()}'] is not matching to object name from upperlevel '{$pickedObject->_PANC_shortName()}' [with value '{$pickedObject->value()}'] ");
+                                    $this->skippedObject( $index, $pickedObject, $ancestor);
+                                    continue;
+                                }
+
                                 if( $this->dupAlg == 'identical' )
                                     if( $pickedObject->name() != $ancestor->name() )
                                     {

--- a/utils/lib/PLAYBOOK__.php
+++ b/utils/lib/PLAYBOOK__.php
@@ -84,7 +84,10 @@ class PLAYBOOK__
 
 //define out to save the final file into this file
         if( isset(PH::$args['out']) )
+        {
             $finaloutput = PH::$args['out'];
+            $output = PH::$args['out'];
+        }
         else
             $finaloutput = null;
 

--- a/utils/lib/PLAYBOOK__.php
+++ b/utils/lib/PLAYBOOK__.php
@@ -225,7 +225,8 @@ class PLAYBOOK__
             "ironskillet-update",
             "maxmind-update",
             "util_get-action-filter",
-            "protocoll-number-download"
+            "protocoll-number-download",
+            "html-merger"
         );
 
         if( isset($details['header-comment']) && !empty($details['header-comment']) )

--- a/utils/lib/PLAYBOOK__.php
+++ b/utils/lib/PLAYBOOK__.php
@@ -84,7 +84,9 @@ class PLAYBOOK__
 
 //define out to save the final file into this file
         if( isset(PH::$args['out']) )
-            $output = PH::$args['out'];
+            $finaloutput = PH::$args['out'];
+        else
+            $finaloutput = null;
 
         if( isset(PH::$args['stagename']) )
             $stage_name = PH::$args['stagename'];
@@ -355,7 +357,7 @@ class PLAYBOOK__
             PH::print_stdout();
         }
 
-        if( isset(PH::$args['out']) && PH::$args['out'] !== "/dev/null" )
+        if( $finaloutput != null && $finaloutput !== "/dev/null" )
         {
             //now save the latest out= from the foreach loop "$out" into "$output" file;
             PH::print_stdout("FINAL script task: the processed PAN-OS configuration are copy to file: ".$output);

--- a/utils/lib/STATSUTIL.php
+++ b/utils/lib/STATSUTIL.php
@@ -53,40 +53,40 @@ class STATSUTIL extends RULEUTIL
 
         if( isset(PH::$args['exportcsv'])  )
         {
-            if( !isset(PH::$args['location']) )
+            $this->exportcsvFile = PH::$args['exportcsv'];
+
+            if( $this->projectFolder !== null )
+                $this->exportcsvFile = $this->projectFolder."/".$this->exportcsvFile;
+
+            if( !isset(PH::$args['location']) || (isset(PH::$args['location']) && PH::$args['location'] === 'shared') )
+            {}
+            elseif( isset(PH::$args['location']) )
             {
-                $this->exportcsvFile = PH::$args['exportcsv'];
-
-                if( $this->projectFolder !== null )
-                    $this->exportcsvFile = $this->projectFolder."/".$this->exportcsvFile;
-
-                //not working because jq can not handling this
-                #$string = json_encode( PH::$JSON_TMP, JSON_PRETTY_PRINT|JSON_FORCE_OBJECT );
-                $string = json_encode( PH::$JSON_TMP, JSON_PRETTY_PRINT );
-
-
-                $jqFile = dirname(__FILE__)."/json2csv.jq";
-
-                //store string into tmp file:
-                $tmpJsonFile = $this->exportcsvFile."tmp_jq_string.json";
-                file_put_contents($tmpJsonFile, $string);
-
-                #$cli = "jq -rf $jqFile <<< $string >> ".$this->exportcsvFile;
-                #$cli = "jq -rf $jqFile <<< \"$string\" >> ".$this->exportcsvFile;
-                #$cli = "jq -rf $jqFile <echo \"$string\") >> ".$this->exportcsvFile;
-                //jq '.key' <(echo \"$json_data\")
-
-                ##working
-                $cli = "jq -rf $jqFile $tmpJsonFile >> ".$this->exportcsvFile;
-
-                #$cli = "echo \"$string\" | jq -rf $jqFile >> ".$this->exportcsvFile;
-
-                exec($cli, $output, $retValue);
-
-                unlink($tmpJsonFile);
+                unset( PH::$JSON_TMP[0] );
             }
-            else
-                mwarning( "exportcsv is right now only supported without argument location=... ", null, false );
+
+            PH::$JSON_TMP = array_values(PH::$JSON_TMP);
+            $string = json_encode( PH::$JSON_TMP, JSON_PRETTY_PRINT );
+
+            #$string = json_encode( PH::$JSON_TMP, JSON_PRETTY_PRINT|JSON_FORCE_OBJECT );
+            #$string = "[".$string."]";
+            #print $string;
+
+            $jqFile = dirname(__FILE__)."/json2csv.jq";
+
+            //store string into tmp file:
+            $tmpJsonFile = $this->exportcsvFile."tmp_jq_string.json";
+            file_put_contents($tmpJsonFile, $string);
+
+            if( file_exists($this->exportcsvFile) )
+                unlink($this->exportcsvFile);
+
+            ##working
+            $cli = "jq -rf $jqFile $tmpJsonFile >> ".$this->exportcsvFile;
+            #$cli = "echo \"$string\" | jq -rf $jqFile >> ".$this->exportcsvFile;
+            exec($cli, $output, $retValue);
+
+            unlink($tmpJsonFile);
         }
 
 

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -1236,28 +1236,67 @@ class UTIL
         // Location Filter Processing
         //
 
-        // <editor-fold desc=" ****  Location Filter Processing  ****" defaultstate="collapsed" >
-        /**
-         * @var RuleStore[] $ruleStoresToProcess
-         */
-        $this->objectsLocation = explode(',', $this->objectsLocation);
-
-        foreach( $this->objectsLocation as $key => &$location )
+        if( strpos( $this->objectsLocation, "," ) !== FALSE )
         {
-            if( strtolower($location) == 'shared' )
-                $this->objectsLocation[$key] = 'shared';
-            else if( strtolower($location) == 'any' )
-                $this->objectsLocation[$key] = 'any';
-            else if( strtolower($location) == 'all' )
+            if( strpos( $this->objectsLocation, ":" ) !== FALSE )
+                derr( "location argument can only handle ',' or ':' not both", null, FALSE );
+            else
             {
-                if( $this->configType == 'fawkes' || $this->configType == 'buckbeak')
-                    $this->objectsLocation[$key] = 'All';
-                else
-                    $this->objectsLocation[$key] = 'any';
-            }
+                // <editor-fold desc=" ****  Location Filter Processing  ****" defaultstate="collapsed" >
+                /**
+                 * @var RuleStore[] $ruleStoresToProcess
+                 */
+                $this->objectsLocation = explode(',', $this->objectsLocation);
 
+                foreach( $this->objectsLocation as $key => &$location )
+                {
+                    if( strtolower($location) == 'shared' )
+                        $this->objectsLocation[$key] = 'shared';
+                    else if( strtolower($location) == 'any' )
+                        $this->objectsLocation[$key] = 'any';
+                    else if( strtolower($location) == 'all' )
+                    {
+                        if( $this->configType == 'fawkes' || $this->configType == 'buckbeak')
+                            $this->objectsLocation[$key] = 'All';
+                        else
+                            $this->objectsLocation[$key] = 'any';
+                    }
+
+                }
+                unset($location);
+            }
         }
-        unset($location);
+        elseif( strpos( $this->objectsLocation, ":" ) !== FALSE )
+        {
+            $loc_explode = explode( ":", $this->objectsLocation );
+
+            if( count( $loc_explode ) > 2 )
+                derr( "location argument with ':' found, can only handle one argument", null, FALSE );
+
+            $rootDG = $loc_explode[0];
+            $opt_argument = strtolower($loc_explode[1]);
+
+            $DG = $this->pan->findDeviceGroup( $rootDG );
+            $childDGs = $DG->childDeviceGroups( TRUE );
+
+            $this->objectsLocation = array();
+
+            $optArgArray = array( "includechilddgs", "excludemaindg" );
+            if( !in_array( $opt_argument, $optArgArray ) )
+                derr( "location has an optional argument which is not supported: '".$opt_argument."' - supported onces: ".implode( ", ", $optArgArray ), null, FALSE );
+
+            if( $opt_argument == "includechilddgs" )
+                $this->objectsLocation[] = $rootDG;
+            elseif( $opt_argument == "excludemaindg" )
+            {}
+
+            foreach( $childDGs as  $dgs )
+                $this->objectsLocation[] = $dgs->name();
+        }
+        else
+            $this->objectsLocation = explode(',', $this->objectsLocation);
+
+
 
         $this->objectsLocation = array_unique($this->objectsLocation);
         if( count( $this->objectsLocation ) == 1 )

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -1277,6 +1277,9 @@ class UTIL
             $opt_argument = strtolower($loc_explode[1]);
 
             $DG = $this->pan->findDeviceGroup( $rootDG );
+            if( $DG === null )
+                $this->locationNotFound($rootDG);
+
             $childDGs = $DG->childDeviceGroups( TRUE );
 
             $this->objectsLocation = array();

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -266,6 +266,7 @@ class UTIL
         $this->supportedArguments['shadow-disableoutputformatting'] = array('niceName' => 'shadow-disableoutputformatting', 'shortHelp' => 'XML output in offline config is not in cleaned PHP DOMDocument structure');
         $this->supportedArguments['shadow-enablexmlduplicatesdeletion']= array('niceName' => 'shadow-enablexmlduplicatesdeletion', 'shortHelp' => 'if duplicate objects are available, keep only one object of the same name');
         $this->supportedArguments['shadow-ignoreinvalidaddressobjects']= array('niceName' => 'shadow-ignoreinvalidaddressobjects', 'shortHelp' => 'PAN-OS allow to have invalid address objects available, like object without value or type');
+        $this->supportedArguments['shadow-apikeyhidden'] = array('niceName' => 'shadow-apikeyhidden', 'shortHelp' => 'send API-KEY hidden via POST. this is possible for all PAN-OS version >=9.0 if API mode is used. ');
         $this->supportedArguments['shadow-apikeynohidden'] = array('niceName' => 'shadow-apikeynohidden', 'shortHelp' => 'send API-KEY in clear text via URL. this is needed for all PAN-OS version <9.0 if API mode is used. ');
         $this->supportedArguments['shadow-apikeynosave']= array('niceName' => 'shadow-apikeynosave', 'shortHelp' => 'do not store API key in .panconfkeystore file');
         $this->supportedArguments['shadow-displaycurlrequest']= array('niceName' => 'shadow-displaycurlrequest', 'shortHelp' => 'display curl information if running in API mode');


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
UTIL:
* type=rule | introduce new 'filter=(uuid eq 1234567890)'
* type=rule | introduce 'actions=name-rename:$$current.name$$-$$uuid$$'
* type=stats | improvement to get exportcsv=file.csv working for argument location
* type=ALL - introduce optional argument for location=DGname:includeChildDgs / location=DGname:excludeMainDg
* type=ALL - introduce again argument shadow-apikeyhidden

BUGFIX:
* type=address/service | fix for actions=name-rename - to skip if string length > 63
* type=address actions=value-host-object-add-netmask-m32 | skip if IPv6 address
* type=playbook | skip creating out file for usage of html-merger
* type=address | improvement for ipv6 if 'actions=name-rename:host.pub_$$value.no-netmask$$-$$netmask$$'
* type=address-merger | bugfix for fqdn objects with different value but same name spread of DG hierarchy
* type=ALL | argument location=DGname:includeChildDgs - bugfix if DG is not found
* type=rule | bugfix for 'filter=(schedule is.expired)'

GENERAL:
* class PanoramaConf | improve output if parentDG can not be calculated for DeviceGroup
* update git-php
* class AddressStore - revert group loop check