### PR TITLE
2.0.66 - new features / bugfix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.0.66
 UTIL:
+* type=address/service | introduce 'filter=(reflocationcount ><=! NUMBER)'
 
 BUGFIX:
 * type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 
 BUGFIX:
 * type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly
+* class ReferenceableObject | bugfix for - type=rule 'filter=(reflocation is.only DGNAME)'
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.0.66
 UTIL:
 * type=address/service | introduce 'filter=(reflocationcount ><=! NUMBER)'
+* type=diff | introduce more options for 'filter=file.json' - 'added'/'deleted'/'moved' to not display xPath diff, if already accepted and known
 
 BUGFIX:
 * type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ BUGFIX:
 * type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly
 * class ReferenceableObject | bugfix for - type=rule 'filter=(reflocation is.only DGNAME)'
 * type=address | bugfix for 'filter=(reflocation is DGNAME)' if multiple reflocation are used
+* class RULE.php method load_common_from_domxml() | bugfix to NOT set reference for group-tag - fix problems with tag-merger
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTIL:
 BUGFIX:
 * type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly
 * class ReferenceableObject | bugfix for - type=rule 'filter=(reflocation is.only DGNAME)'
+* type=address | bugfix for 'filter=(reflocation is DGNAME)' if multiple reflocation are used
 
 GENERAL
 

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -717,13 +717,10 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is'] = array(
         foreach( $reflocation_array as $reflocation )
         {
             if( strtolower($reflocation) == strtolower($context->value) )
-                $return =  TRUE;
-            else
-                $return =  FALSE;
+                return TRUE;
         }
 
-
-        return $return;
+        return FALSE;
     },
     'arg' => TRUE,
     'help' => 'returns TRUE if object location (shared/device-group/vsys name) matches',
@@ -763,7 +760,7 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is.only'] = arra
             if( strtolower($reflocation) == strtolower($context->value) )
                 $return = TRUE;
             else
-                $return = FALSE;
+                return FALSE;
         }
 
         /*if( count($reflocation_array) == 1 && $return )

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -682,8 +682,8 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is'] = array(
         $object = $context->object;
         $owner = $context->object->owner->owner;
 
+        #print "NAME: ".$object->name()."\n";
         $reflocation_array = $object->getReferencesLocation();
-
         #print_r( $reflocation_array );
 
 
@@ -706,15 +706,17 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is'] = array(
             }
         }
 
-
+        $return = FALSE;
         foreach( $reflocation_array as $reflocation )
         {
             if( strtolower($reflocation) == strtolower($context->value) )
-                return TRUE;
+                $return =  TRUE;
+            else
+                $return =  FALSE;
         }
 
 
-        return FALSE;
+        return $return;
     },
     'arg' => TRUE,
     'help' => 'returns TRUE if object location (shared/device-group/vsys name) matches',
@@ -726,7 +728,9 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is'] = array(
 RQuery::$defaultFilters['address']['reflocation']['operators']['is.only'] = array(
     'Function' => function (AddressRQueryContext $context) {
         $owner = $context->object->owner->owner;
-        $reflocations = $context->object->getReferencesLocation();
+        $object = $context->object;
+
+        $reflocation_array = $object->getReferencesLocation();
 
         /*
                 $DG = $owner->findDeviceGroup( $context->value );
@@ -747,17 +751,20 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is.only'] = arra
         }
 
         $return = FALSE;
-        foreach( $reflocations as $reflocation )
+        foreach( $reflocation_array as $reflocation )
         {
             if( strtolower($reflocation) == strtolower($context->value) )
                 $return = TRUE;
+            else
+                $return = FALSE;
         }
 
-        if( count($reflocations) == 1 && $return )
+        /*if( count($reflocation_array) == 1 && $return )
             return TRUE;
         else
             return FALSE;
-
+        */
+        return $return;
     },
     'arg' => TRUE,
     'help' => 'returns TRUE if object location (shared/device-group/vsys name) matches',

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -10,6 +10,14 @@ RQuery::$defaultFilters['address']['refcount']['operators']['>,<,=,!'] = array(
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['address']['reflocationcount']['operators']['>,<,=,!'] = array(
+    'eval' => '$object->countLocationReferences() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 RQuery::$defaultFilters['address']['object']['operators']['is.unused'] = array(
     'Function' => function (AddressRQueryContext $context) {
         return $context->object->countReferences() == 0;
@@ -685,7 +693,6 @@ RQuery::$defaultFilters['address']['reflocation']['operators']['is'] = array(
         #print "NAME: ".$object->name()."\n";
         $reflocation_array = $object->getReferencesLocation();
         #print_r( $reflocation_array );
-
 
         if( strtolower($context->value) == 'shared' )
         {

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -1369,6 +1369,9 @@ RQuery::$defaultFilters['rule']['service']['operators']['no.app-default.ports'] 
     {
         $rule = $context->object;
 
+        if( !$rule->isSecurityRule() )
+            return FALSE;
+
         if( $rule->services->isApplicationDefault())
             return false;
 

--- a/lib/misc-classes/filters/filters-Service.php
+++ b/lib/misc-classes/filters/filters-Service.php
@@ -10,6 +10,14 @@ RQuery::$defaultFilters['service']['refcount']['operators']['>,<,=,!'] = array(
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['service']['reflocationcount']['operators']['>,<,=,!'] = array(
+    'eval' => '$object->countLocationReferences() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
 RQuery::$defaultFilters['service']['object']['operators']['is.unused'] = array(
     'Function' => function (ServiceRQueryContext $context) {
         return $context->object->countReferences() == 0;

--- a/lib/misc-classes/trait/ReferenceableObject.php
+++ b/lib/misc-classes/trait/ReferenceableObject.php
@@ -129,6 +129,12 @@ trait ReferenceableObject
         return count($this->refrules);
     }
 
+    public function countLocationReferences()
+    {
+        $refLocationcounter = array();
+        $this->getReferencesLocation($refLocationcounter);
+        return count($refLocationcounter);
+    }
 
     public function display_references($indent = 0)
     {

--- a/lib/misc-classes/trait/ReferenceableObject.php
+++ b/lib/misc-classes/trait/ReferenceableObject.php
@@ -233,37 +233,70 @@ trait ReferenceableObject
         $location_array = array();
         foreach( $this->refrules as $cur )
         {
+            #print "--------------\n";
             #print get_class( $cur)."\n";
-            //Firewall
-            if( isset($cur->owner->owner) && $cur->owner->owner !== null && method_exists($cur->owner->owner,'name') && $cur->owner->owner->name() !== "")
+            #print $cur->name()."\n";
+            if( isset($cur->owner->owner->owner->owner) && get_class( $cur->owner->owner->owner->owner ) == "PanoramaConf" )
             {
-                #print $cur->owner->owner->name()."\n";
-                $location_array[$cur->owner->owner->name()] = $cur->owner->owner->name();
-                if( isset($counter_array[$cur->owner->owner->name()]))
-                    $counter_array[$cur->owner->owner->name()] += 1;
-                else
-                    $counter_array[$cur->owner->owner->name()] = 1;
+                //Panorama - Rule
+                if( isset($cur->owner->owner->owner) && $cur->owner->owner->owner !== null && method_exists($cur->owner->owner->owner,'name') && $cur->owner->owner->owner->name() !== "")
+                {
+                    #print "pan | ".$cur->owner->owner->owner->name()."\n";
+                    $location_array[$cur->owner->owner->owner->name()] = $cur->owner->owner->owner->name();
+                    if( isset($counter_array[$cur->owner->owner->owner->name()]))
+                        $counter_array[$cur->owner->owner->owner->name()] += 1;
+                    else
+                        $counter_array[$cur->owner->owner->owner->name()] = 1;
+                }
             }
-
-            //Panorama
-            if( isset($cur->owner->owner->owner) && $cur->owner->owner->owner !== null && method_exists($cur->owner->owner->owner,'name') && $cur->owner->owner->owner->name() !== "")
+            elseif( isset($cur->owner->owner->owner) && get_class( $cur->owner->owner->owner ) == "PanoramaConf" )
             {
-                #print $cur->owner->owner->owner->name()."\n";
-                $location_array[$cur->owner->owner->owner->name()] = $cur->owner->owner->owner->name();
-                if( isset($counter_array[$cur->owner->owner->owner->name()]))
-                    $counter_array[$cur->owner->owner->owner->name()] += 1;
-                else
-                    $counter_array[$cur->owner->owner->owner->name()] = 1;
+                #Panorama - AddressGroup
+                if( isset($cur->owner->owner) && $cur->owner->owner !== null && method_exists($cur->owner->owner,'name') && $cur->owner->owner->name() !== "")
+                {
+                    #print "pan-fw | ".$cur->owner->owner->name()."\n";
+                    $location_array[$cur->owner->owner->name()] = $cur->owner->owner->name();
+                    if( isset($counter_array[$cur->owner->owner->name()]))
+                        $counter_array[$cur->owner->owner->name()] += 1;
+                    else
+                        $counter_array[$cur->owner->owner->name()] = 1;
+                }
+            }
+            else
+            {
+                //possible to be on FW?????
+                if( isset($cur->owner->owner->owner) && $cur->owner->owner->owner !== null && method_exists($cur->owner->owner->owner,'name') && $cur->owner->owner->owner->name() !== "")
+                {
+                    #print "fw-pan | ".$cur->owner->owner->owner->name()."\n";
+                    $location_array[$cur->owner->owner->owner->name()] = $cur->owner->owner->owner->name();
+                    if( isset($counter_array[$cur->owner->owner->owner->name()]))
+                        $counter_array[$cur->owner->owner->owner->name()] += 1;
+                    else
+                        $counter_array[$cur->owner->owner->owner->name()] = 1;
+                }
+                //Firewall
+                elseif( isset($cur->owner->owner) && $cur->owner->owner !== null && method_exists($cur->owner->owner,'name') && $cur->owner->owner->name() !== "")
+                {
+                    #print "fw | ".$cur->owner->owner->name()."\n";
+                    $location_array[$cur->owner->owner->name()] = $cur->owner->owner->name();
+                    if( isset($counter_array[$cur->owner->owner->name()]))
+                        $counter_array[$cur->owner->owner->name()] += 1;
+                    else
+                        $counter_array[$cur->owner->owner->name()] = 1;
+                }
             }
 
 
             if( get_class( $cur ) == "AddressGroup" || get_class( $cur ) == "ServiceGroup"  )
             {
-                $recursive_loc_array = $cur->getReferencesLocation( );
-                $location_array = array_merge( $location_array, $recursive_loc_array );
+                //why is this needed
+                    ##print $cur->name()."\n";
+                #$recursive_loc_array = $cur->getReferencesLocation( );
+                    ##print_r( $recursive_loc_array );
+                #$location_array = array_merge( $location_array, $recursive_loc_array );
             }
         }
-
+        #print_r($location_array);
         return $location_array;
     }
     

--- a/lib/rule-classes/Rule.php
+++ b/lib/rule-classes/Rule.php
@@ -184,7 +184,7 @@ class Rule
             else if( $node->nodeName == 'group-tag' )
             {
                 $grouptagName = $node->textContent;
-                $this->grouptag = $this->owner->owner->tagStore->find( $grouptagName, $this);
+                $this->grouptag = $this->owner->owner->tagStore->find( $grouptagName, $this->grouptag);
             }
             else if( $node->nodeName == 'description' )
             {

--- a/utils/develop/gcp.php
+++ b/utils/develop/gcp.php
@@ -38,12 +38,15 @@ PH::processCliArgs();
 
 $tenantID = null;
 $http_auth_IP = "10.181.137.2";
-$http_auth_IP = "10.181.244.2";
-$http_auth_IP = "10.181.244.66";
+#$http_auth_IP = "10.181.244.2";
+#$http_auth_IP = "10.181.244.66";
 $inputconfig = null;
 $outputfilename = null;
 $displayOutput = true;
 $configPath = "/opt/pancfg/mgmt/saved-configs/";
+#$configPath = "/opt/pancfg/mgmt/factory/";
+#$configPath = "/tmp/";
+
 $insecureValue = "--insecure-skip-tls-verify=true";
 
 
@@ -225,15 +228,23 @@ elseif( $action == "expedition-log" )
 }
 elseif( $action == "upload" )
 {
-    if( $outputfilename === null )
+    if( $inputconfig === null )
         derr( "argument 'in=/PATH/FILENAME' is not specified" );
     if( $outputfilename === null )
-        derr( "argument 'out=FILENAME' is not specified" );
+    {
+        #derr( "argument 'out=FILENAME' is not specified" );
+        $tmpArray = explode( "/", $inputconfig );
+        if( count( $tmpArray ) == 1 )
+            $outputfilename = $inputconfig;
+        elseif( count( $tmpArray ) > 1 )
+            $outputfilename = end($tmpArray);
+    }
     $tmpArray = explode( "/", $outputfilename );
     if( count( $tmpArray ) > 1 )
         derr( "argument 'out=FILENAME' is only with FILENAME not a PATH allowed" );
+    $container = substr($tenantID, 0, -2);
 
-    $cli = "kubectl ".$insecureValue." cp ".$inputconfig." ".$tenantID.":".$configPath.$outputfilename;
+    $cli = "kubectl ".$insecureValue." cp ".$inputconfig." -c ".$container." ".$tenantID.":".$configPath.$outputfilename;
     execCLIWithOutput( $cli );
 }
 elseif( $action == "download" )


### PR DESCRIPTION
## Description

2.0.66
UTIL:
* type=address/service | introduce 'filter=(reflocationcount ><=! NUMBER)'
* type=diff | introduce more options for 'filter=file.json' - 'added'/'deleted'/'moved' to not display xPath diff, if already accepted and known

BUGFIX:
* type=rule-merger | bugfix if argument exportcsv=xyz projectfolder=xyz and rules are skipped - to create skipped output file correctly
* class ReferenceableObject | bugfix for - type=rule 'filter=(reflocation is.only DGNAME)'
* type=address | bugfix for 'filter=(reflocation is DGNAME)' if multiple reflocation are used
* class RULE.php method load_common_from_domxml() | bugfix to NOT set reference for group-tag - fix problems with tag-merger

GENERAL