### PR TITLE
version 2.0.72

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.0.72
 UTIL:
 * type=upload | improvement if in=api:// is used but no out= is defined
+* type=device | actions=display-shadowrule:file.html - improvement to store full rule informtaion into html
 
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.0.71
+2.0.72
+UTIL:
+
+BUGFIX:
+
+GENERAL
+
+
+2.0.71 (20230215)
 UTIL:
 * type=certificate | introduction of new utility script
 * type=certificate | extend actions=display
@@ -16,25 +24,16 @@ GENERAL
 * update Dockerfiles | split correctly between amd/arm
 
 
-2.0.70
+2.0.70 (20230208)
 UTIL:
 * type=diff | redesign filter JSON "combinedruleordercheck" feature
-* type=certificate | introduction of new utility script
-* type=certificate | extend actions=display
-* type=device | actions=display-shadowrule - extend with argument exportToexcel | actions=display-shadowrule:filename.html
 
 BUGFIX:
-* type=diff - JSON filter file - regression bug for "empty"
-* type=diff | bugfix for filter=jsonfile.json | not handling xpath split correctly
-* type=diff | bugfix filter JSON file "EMPTY" part
-* type=diff | JSON filter file - fix ruleorder display for "combinedruleordercheck"
 * type=playbook | bugfix for missing validation of available array_key
 * type=ironskilled-update | bugfix as ironskillet zpp has nothing for Alert_Only_Zone_Protection
 * type=address-merger | bugfix class Address.php - not handled null validation
 
 GENERAL
-* update dockerfiles to adjust for github actions
-* pan-os-php version shadow-json | remove second duplicate output
 * general - update UTIL actions/filter
 * update Dockerfiles | split correctly between amd/arm
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=upload | improvement if in=api:// is used but no out= is defined
 * type=device | actions=display-shadowrule:file.html - improvement to store full rule informtaion into html
 * type=certificate | introduce 'filter=(publickey-algorithm is.rsa/is.ec) - publickey-hash is.sha1/is.sha256/is.sha384/is.sha512 - publickey-length <>!= VALUE
+* type=certificate | introduce 'filter=(publickey-hash < sha256)'
 
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.0.72
 UTIL:
+* type=upload | improvement if in=api:// is used but no out= is defined
 
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys
+* type=rule ruletype=defaultsecurity | bugfix to read predefined default-security-rules also if xpath post-rulebase is not set
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ BUGFIX:
 * type=device | actions=display-shadowrule devicetype=manageddevice - bugfix for html export to display correct serial/DG
 
 GENERAL
+* class Rule | improvement for type=rule 'filter=(hit-count.fast, timestamp-last-hit.fast and timestamp-first-hit.fast
 
 
 2.0.71 (20230215)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys
 * type=rule ruletype=defaultsecurity | bugfix to read predefined default-security-rules also if xpath post-rulebase is not set
 * type=device actions=display-shadowrule | bugfix for multi-vsys
+* type=device | actions=display-shadowrule devicetype=manageddevice - bugfix for html export to display correct serial/DG
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys
 * type=rule ruletype=defaultsecurity | bugfix to read predefined default-security-rules also if xpath post-rulebase is not set
+* type=device actions=display-shadowrule | bugfix for multi-vsys
 
 GENERAL
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=upload | improvement if in=api:// is used but no out= is defined
 * type=device | actions=display-shadowrule:file.html - improvement to store full rule informtaion into html
+* type=certificate | introduce 'filter=(publickey-algorithm is.rsa/is.ec) - publickey-hash is.sha1/is.sha256/is.sha384/is.sha512 - publickey-length <>!= VALUE
 
 BUGFIX:
 * type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys

--- a/lib/device-and-system-classes/DeviceGroup.php
+++ b/lib/device-and-system-classes/DeviceGroup.php
@@ -854,23 +854,17 @@ class DeviceGroup
         else
             $tmp = null;
         if( $postrulebase === FALSE )
-            $tmpPost = null;
-        else
         {
-            /*
-            $tmpPost = DH::findFirstElement($xmlTagName, $postrulebase);
-            if( $tmpPost !== FALSE )
-                $tmpPost = DH::findFirstElement('rules', $tmpPost);
+            #$tmpPost = null;
+            $postrulebase = DH::findFirstElementOrCreate('post-rulebase', $xml);
+        }
 
-            if( $tmpPost === FALSE )
-            {
-                $tmpPost = null;
-            */
+        #else{
             $sub = new Sub();
             $sub->rulebaseroot = $postrulebase;
             $sub->defaultSecurityRules = $this->defaultSecurityRules;
             $tmpPost = $sub->load_defaultSecurityRule( );
-        }
+        #}
         if( $tmpPost !== FALSE )
             $this->$var->load_from_domxml($tmp, $tmpPost);
 

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -991,23 +991,17 @@ class PanoramaConf
         else
             $tmp = null;
         if( $postrulebase === FALSE )
-            $tmpPost = null;
-        else
         {
-            /*
-            $tmpPost = DH::findFirstElement('default-security-rules', $postrulebase);
-            if( $tmpPost !== FALSE )
-                $tmpPost = DH::findFirstElement('rules', $tmpPost);
+            #$tmpPost = null;
+            $postrulebase = DH::findFirstElementOrCreate('post-rulebase', $this->sharedroot);
+        }
 
-            if( $tmpPost === FALSE )
-            {
-                $tmpPost = null;
-            */
+        #else{
             $sub = new Sub();
             $sub->rulebaseroot = $postrulebase;
             $sub->defaultSecurityRules = $this->defaultSecurityRules;
             $tmpPost = $sub->load_defaultSecurityRule( );
-        }
+        #}
         if( $tmpPost !== FALSE )
             $this->defaultSecurityRules->load_from_domxml($tmp, $tmpPost);
 

--- a/lib/device-and-system-classes/Sub.php
+++ b/lib/device-and-system-classes/Sub.php
@@ -55,7 +55,11 @@ class Sub
         }
 
         if( $tmproot === FALSE )
+        {
+            //Pan
             $finalroot = $this->createDefaultSecurityRule( );
+        }
+
 
         return $finalroot;
     }

--- a/lib/misc-classes/CertificateRQueryContext.php
+++ b/lib/misc-classes/CertificateRQueryContext.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Class CertificateRQueryContext
+ * @property Certificate $object
+ * @ignore
+ */
+class CertificateRQueryContext extends RQueryContext
+{
+
+}

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -1108,4 +1108,19 @@ class PH
 
         return $util;
     }
+
+    public static function find_string_between($line, $needle1, $needle2 = "--END--")
+    {
+        $needle_length = strlen($needle1);
+        $pos1 = strpos($line, $needle1);
+
+        if( $needle2 !== "--END--" )
+            $pos2 = strpos($line, $needle2);
+        else
+            $pos2 = strlen($line);
+
+        $finding = substr($line, $pos1 + $needle_length, $pos2 - ($pos1 + $needle_length));
+
+        return $finding;
+    }
 }

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -161,7 +161,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 0;
-    private static $library_version_bugfix = 71;
+    private static $library_version_bugfix = 72;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -939,7 +939,8 @@ class PH
         "protocoll-number-download",
         "html-merger",
         "tsf",
-        "xpath"
+        "xpath",
+        "certificate"
         );
 
 

--- a/lib/misc-classes/PanAPIConnector.php
+++ b/lib/misc-classes/PanAPIConnector.php
@@ -2115,7 +2115,7 @@ class PanAPIConnector
         return $password;
     }
 
-    public function getShadowInfo( $countInfo, $panorama = false, $devicegroupname = "" )
+    public function getShadowInfo( $countInfo, $panorama = false, $devicegroupname = "", $manageddevice = false )
     {
         $cmd = "<show><shadow-warning><count>".$countInfo."</count></shadow-warning></show>";
         $response = $this->sendOpRequest( $cmd );
@@ -2137,7 +2137,7 @@ class PanAPIConnector
             if( $panorama )
             {
                 $name = $entry->getAttribute("dg");
-                if( $devicegroupname !== $name )
+                if( !$manageddevice && $devicegroupname !== $name )
                     continue;
 
                 $devicegroup = "<device-group>" . $name . "</device-group>";

--- a/lib/misc-classes/PanAPIConnector.php
+++ b/lib/misc-classes/PanAPIConnector.php
@@ -2002,8 +2002,10 @@ class PanAPIConnector
 
         $fakePanorama->load_from_xmlstring($panoramaString);
 
+        $firewall = new PANConf($fakePanorama);
+        #$firewall->connector = $this;
 
-        return new PANConf($fakePanorama);
+        return $firewall;
     }
 
     /**

--- a/lib/misc-classes/RQuery.php
+++ b/lib/misc-classes/RQuery.php
@@ -103,6 +103,8 @@ class RQuery
             $this->contextObject = new InterfaceRQueryContext($this);
         elseif( $this->objectType == 'dhcp' )
             $this->contextObject = new DHCPRQueryContext($this);
+        elseif( $this->objectType == 'certificate' )
+            $this->contextObject = new CertificateRQueryContext($this);
         else
             derr("unsupported object type '$objectType'");
     }
@@ -688,5 +690,6 @@ require_once 'filters/filters-SecurityProfileGroup.php';
 require_once 'filters/filters-Schedule.php';
 require_once 'filters/filters-Device.php';
 require_once 'filters/filters-DHCP.php';
+require_once 'filters/filters-Certificate.php';
 
 

--- a/lib/misc-classes/filters/filters-Certificate.php
+++ b/lib/misc-classes/filters/filters-Certificate.php
@@ -1,0 +1,90 @@
+<?php
+
+RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.rsa'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyAlgorithm() == "rsa" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.ec'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyAlgorithm() == "ec" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+
+RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha1'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyHash() == "sha1" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha256'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyHash() == "sha256" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha384'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyHash() == "sha384" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha512'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        if( $context->object->getPkeyHash() == "sha512" )
+            return TRUE;
+        else
+            return FALSE;
+    },
+    'arg' => FALSE,
+    'ci' => array(
+        'fString' => '(%PROP%)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+
+RQuery::$defaultFilters['certificate']['publickey-length']['operators']['>,<,=,!'] = array(
+    'eval' => '$object->getPkeyBits() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);

--- a/lib/misc-classes/filters/filters-Certificate.php
+++ b/lib/misc-classes/filters/filters-Certificate.php
@@ -97,7 +97,40 @@ RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha512
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['>,<,=,!'] = array(
+    'Function' => function (CertificateRQueryContext $context) {
+        $object = $context->object;
+        $arg = $context->value;
 
+        $operator = $context->operator;
+        if( $operator == '=' )
+            $operator = '==';
+
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
+        $hashvalue = $context->object->getPkeyHash();
+        $hashvalue = str_replace( "sha", "", $hashvalue );
+
+        $hashvaluesearch = $arg;
+        if( strpos( $hashvaluesearch, "sha" ) !== FALSE )
+        {
+            $hashvaluesearch = str_replace( "sha", "", $hashvaluesearch );
+        }
+
+        $operator_string = $hashvalue." ".$operator." ".$hashvaluesearch;
+        if( eval("return $operator_string;" ) )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => true,
+    'help' => 'returns TRUE if object hash value matches "publickey-hash >= 256" || "publickey-hash < sha256"',
+    'ci' => array(
+    'fString' => '(%PROP% 5)',
+    'input' => 'input/panorama-8.0.xml'
+)
+);
 RQuery::$defaultFilters['certificate']['publickey-length']['operators']['>,<,=,!'] = array(
     'eval' => '$object->hasPublicKey() && $object->getPkeyBits() !operator! !value!',
     'arg' => TRUE,

--- a/lib/misc-classes/filters/filters-Certificate.php
+++ b/lib/misc-classes/filters/filters-Certificate.php
@@ -2,6 +2,9 @@
 
 RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.rsa'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyAlgorithm() == "rsa" )
             return TRUE;
         else
@@ -15,6 +18,9 @@ RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.r
 );
 RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.ec'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyAlgorithm() == "ec" )
             return TRUE;
         else
@@ -29,6 +35,9 @@ RQuery::$defaultFilters['certificate']['publickey-algorithm']['operators']['is.e
 
 RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha1'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyHash() == "sha1" )
             return TRUE;
         else
@@ -42,6 +51,9 @@ RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha1']
 );
 RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha256'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyHash() == "sha256" )
             return TRUE;
         else
@@ -55,6 +67,9 @@ RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha256
 );
 RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha384'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyHash() == "sha384" )
             return TRUE;
         else
@@ -68,6 +83,9 @@ RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha384
 );
 RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha512'] = array(
     'Function' => function (CertificateRQueryContext $context) {
+        if( !$context->object->hasPublicKey() )
+            return FALSE;
+
         if( $context->object->getPkeyHash() == "sha512" )
             return TRUE;
         else
@@ -81,7 +99,7 @@ RQuery::$defaultFilters['certificate']['publickey-hash']['operators']['is.sha512
 );
 
 RQuery::$defaultFilters['certificate']['publickey-length']['operators']['>,<,=,!'] = array(
-    'eval' => '$object->getPkeyBits() !operator! !value!',
+    'eval' => '$object->hasPublicKey() && $object->getPkeyBits() !operator! !value!',
     'arg' => TRUE,
     'ci' => array(
         'fString' => '(%PROP% 1)',

--- a/lib/network-classes/Certificate.php
+++ b/lib/network-classes/Certificate.php
@@ -254,6 +254,14 @@ class Certificate
         $this->setName($newname);
     }
 
+    public function hasPublicKey()
+    {
+        if( $this->publicKey !== null )
+            return true;
+
+        return false;
+    }
+
     public function getPkeyAlgorithm()
     {
         return $this->publicKeyAlgorithm;

--- a/lib/pan_php_framework.php
+++ b/lib/pan_php_framework.php
@@ -179,6 +179,10 @@ require_once $basedir . '/misc-classes/SecurityProfileGroupRQueryContext.php';
 
 require_once $basedir . '/misc-classes/DeviceRQueryContext.php';
 
+require_once $basedir . '/misc-classes/DHCPRQueryContext.php';
+require_once $basedir . '/misc-classes/CertificateRQueryContext.php';
+
+
 require_once $basedir . '/misc-classes/CsvParser.php';
 require_once $basedir . '/misc-classes/trait/PanSubHelperTrait.php';
 require_once $basedir . '/misc-classes/PanAPIConnector.php';

--- a/lib/rule-classes/NatRule.php
+++ b/lib/rule-classes/NatRule.php
@@ -308,7 +308,7 @@ class NatRule extends Rule
                         }
                         else
                         {
-                            mwarning("Unknown dynamic SNAT type on rule '" . $this->name . " don't mess too much with this rule or face unpredictable results", null, FALSE);
+                            mwarning("Unknown dynamic SNAT type on rule '" . $this->name . "' owner: ".$this->owner->owner->_PANC_shortName()." don't mess too much with this rule or face unpredictable results", null, FALSE);
                         }
                     }
 

--- a/lib/rule-classes/Rule.php
+++ b/lib/rule-classes/Rule.php
@@ -1442,8 +1442,6 @@ class Rule
 
         if( !isset($sub->apiCache) )
             $sub->apiCache = array();
-        if( !isset($sub->apiChecked) )
-            $sub->apiChecked = array();
 
         // caching results for speed improvements
         if( !isset($sub->apiCache[$unused_flag]) )
@@ -1522,10 +1520,14 @@ class Rule
 
                         if( !$firstLoop )
                         {
-                            foreach( $sub->apiCache[$unused_flag] as $unusedEntry )
+                            $operator = $context->operator;
+                            if($operator == "is.unused.fast")
                             {
-                                if( !isset($tmpCache[$unusedEntry]) )
-                                    unset($sub->apiCache[$unused_flag][$unusedEntry]);
+                                foreach( $sub->apiCache[$unused_flag] as $unusedEntry )
+                                {
+                                    if( !isset($tmpCache[$unusedEntry]) )
+                                        unset($sub->apiCache[$unused_flag][$unusedEntry]);
+                                }
                             }
                         }
 
@@ -1596,11 +1598,12 @@ class Rule
                                 if( eval("return $operator_string;" ) )
                                 {
                                     //match, no unset
-                                    $sub->apiChecked[$unused_flag][$ruleName] = $ruleName;
+                                    if( !isset($sub->apiCache[$unused_flag][$ruleName]) )
+                                        $sub->apiCache[$unused_flag][$ruleName] = $ruleName;
                                 }
                                 else
                                 {
-                                    if( !isset($sub->apiChecked[$unused_flag][$ruleName]) && isset($sub->apiCache[$unused_flag][$ruleName]) )
+                                    if( isset($sub->apiCache[$unused_flag][$ruleName]) )
                                         unset($sub->apiCache[$unused_flag][$ruleName]);
                                 }
                             }
@@ -1620,16 +1623,18 @@ class Rule
                             if( $operator == '==' && $timestamp_value == 0 )
                             {
                                 //match, no unset
-                                $sub->apiChecked[$unused_flag][$ruleName] = $ruleName;
+                                if( !isset($sub->apiCache[$unused_flag][$ruleName]) )
+                                    $sub->apiCache[$unused_flag][$ruleName] = $ruleName;
                             }
                             elseif( $timestamp_value != 0 && eval("return $operator_string;" ) )
                             {
                                 //match, no unset
-                                $sub->apiChecked[$unused_flag][$ruleName] = $ruleName;
+                                if( !isset($sub->apiCache[$unused_flag][$ruleName]) )
+                                    $sub->apiCache[$unused_flag][$ruleName] = $ruleName;
                             }
                             else
                             {
-                                if( !isset($sub->apiChecked[$unused_flag][$ruleName]) && isset($sub->apiCache[$unused_flag][$ruleName]) )
+                                if( isset($sub->apiCache[$unused_flag][$ruleName]) )
                                     unset($sub->apiCache[$unused_flag][$ruleName]);
                             }
                         }

--- a/utils/common/actions-certificate.php
+++ b/utils/common/actions-certificate.php
@@ -31,7 +31,15 @@ CertificateCallContext::$supportedActions['display'] = Array(
         $algorithm = "";
         $privateKey = "";
         $privateKeyLen = "";
+
+
+        $notValidbefore = "";
+        $notValidafter = "";
+
         $publicKeyLen = "";
+        $publicKeyAlgorithm = "";
+        $publicKeyHash = "";
+
         if( $object->algorithm != null )
             $algorithm = "Algorithm: ".$object->algorithm;
 
@@ -44,20 +52,24 @@ CertificateCallContext::$supportedActions['display'] = Array(
         {
             $privateKey = $object->privateKey;
             $privateKeyLen = "       - "."privateKey length: ".$object->privateKeyLen;
+            #$privateKeyAlgorithm = " | algorithm: ".$object->privateKeyAlgorithm;
+            #$prviateKeyHash = " |  hash: ".$object->privateKeyHash;
         }
 
-        if( $object->privateKey != null )
+        if( $object->publicKey != null )
         {
             $publicKey = $object->publicKey;
-            $publicKeyLen = " | publicKey length: ".$object->publicKeyLen;
+            $publicKeyLen = "       - "."publicKey length: ".$object->publicKeyLen;
+            $publicKeyAlgorithm = " | algorithm: ".$object->publicKeyAlgorithm;
+            $publicKeyHash = " |  hash: ".$object->publicKeyHash;
         }
         //not-valid-before
         //not-valid-after
 
         PH::print_stdout( "       - ".$algorithm.$notValidbefore." - ".$notValidafter );
-        PH::print_stdout( $privateKeyLen.$publicKeyLen );
+        PH::print_stdout( $privateKeyLen);
+        #PH::print_stdout( $privateKeyLen.$privateKeyAlgorithm.$prviateKeyHash );
+        PH::print_stdout( $publicKeyLen.$publicKeyAlgorithm.$publicKeyHash );
     },
-
-    //Todo: display routes to zone / Interface IP
 );
 

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -1294,7 +1294,7 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
         }
 
         PH::$JSON_TMP['sub'] = $jsonArray;
-        $context->jsonArray = $jsonArray;
+        $context->jsonArray[$type_name] = $jsonArray;
     },
     'GlobalFinishFunction' => function (DeviceCallContext $context) {
             $filename = $context->arguments['exportToExcel'];
@@ -1336,31 +1336,35 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                 };
 
 
-                $headers = '<th>ruletype</th><th>rule</th><th>shadow rule</th>';
+                $headers = '<th>sub</th><th>ruletype</th><th>rule</th><th>shadow rule</th>';
 
                 $count = 0;
 
-                    foreach( $context->jsonArray as $keyruletype => $ruletype )
+                    foreach( $context->jsonArray as $subtype => $sub )
                     {
-                        foreach( $ruletype as $keyrule => $rule )
+                        foreach( $sub as $keyruletype => $ruletype )
                         {
-                            foreach( $rule as $ruleItem )
+                            foreach( $ruletype as $keyrule => $rule )
                             {
-                                $count++;
+                                foreach( $rule as $ruleItem )
+                                {
+                                    $count++;
 
-                                /** @var Tag $object */
-                                if( $count % 2 == 1 )
-                                    $lines .= "<tr>\n";
-                                else
-                                    $lines .= "<tr bgcolor=\"#DDDDDD\">";
+                                    /** @var Tag $object */
+                                    if( $count % 2 == 1 )
+                                        $lines .= "<tr>\n";
+                                    else
+                                        $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                                #$lines .= $encloseFunction(PH::getLocationString($object));
+                                    #$lines .= $encloseFunction(PH::getLocationString($object));
 
-                                $lines .= $encloseFunction($keyruletype);
-                                $lines .= $encloseFunction($keyrule);
-                                $lines .= $encloseFunction($ruleItem);
+                                    $lines .= $encloseFunction($subtype);
+                                    $lines .= $encloseFunction($keyruletype);
+                                    $lines .= $encloseFunction($keyrule);
+                                    $lines .= $encloseFunction($ruleItem);
 
-                                $lines .= "</tr>\n";
+                                    $lines .= "</tr>\n";
+                                }
                             }
                         }
                     }

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -1245,7 +1245,76 @@ var subjectObject =
                 "MainFunction": {}
             }
         },
-        "filter": []
+        "filter": {
+            "publickey-algorithm": {
+                "operators": {
+                    "is.rsa": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.ec": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "publickey-hash": {
+                "operators": {
+                    "is.sha1": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha256": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha384": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha512": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "publickey-length": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "$object->getPkeyBits() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            }
+        }
     },
     "config-commit": {
         "name": "config-commit",

--- a/utils/lib/UPLOAD.php
+++ b/utils/lib/UPLOAD.php
@@ -37,6 +37,13 @@ class UPLOAD extends UTIL
         $this->help(PH::$args);
         $this->arg_validation();
 
+        if( isset(PH::$args['in']) )
+        {
+            if( strpos( PH::$args['in'], "api://") !== false && !isset(PH::$args['out']) )
+            {
+                $this->display_error_usage_exit('"out" argument is missing');
+            }
+        }
 
         //from init_arguments - which is triggered by utilInit
         $this->inDebugapiArgument();

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -1244,7 +1244,76 @@
                 "MainFunction": {}
             }
         },
-        "filter": []
+        "filter": {
+            "publickey-algorithm": {
+                "operators": {
+                    "is.rsa": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.ec": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "publickey-hash": {
+                "operators": {
+                    "is.sha1": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha256": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha384": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    },
+                    "is.sha512": {
+                        "Function": {},
+                        "arg": false,
+                        "ci": {
+                            "fString": "(%PROP%)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "publickey-length": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "$object->getPkeyBits() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            }
+        }
     },
     "config-commit": {
         "name": "config-commit",


### PR DESCRIPTION
UTIL:
* type=upload | improvement if in=api:// is used but no out= is defined
* type=device | actions=display-shadowrule:file.html - improvement to store full rule informtaion into html
* type=certificate | introduce 'filter=(publickey-algorithm is.rsa/is.ec) - publickey-hash is.sha1/is.sha256/is.sha384/is.sha512 - publickey-length <>!= VALUE
* type=certificate | introduce 'filter=(publickey-hash < sha256)'

BUGFIX:
* type=device | bugfix actions=display-shadowrule:file.html - to export correctly for all DG/vsys
* type=rule ruletype=defaultsecurity | bugfix to read predefined default-security-rules also if xpath post-rulebase is not set
* type=device actions=display-shadowrule | bugfix for multi-vsys
* type=device | actions=display-shadowrule devicetype=manageddevice - bugfix for html export to display correct serial/DG

GENERAL
* class Rule | improvement for type=rule 'filter=(hit-count.fast, timestamp-last-hit.fast and timestamp-first-hit.fast
