### PR TITLE
version 2.1.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 
 BUGFIX:
 * type=vendor-migration vendor=ciscoasa | fix to avoid none object to read isGroup()
+* type=vendor-migration vendor=ciscoasa | bugfix for creating service - to not add e.g. tacacs as service port
 
 GENERAL:
 - update dynamic content to Device App-ID version: 8708-8036

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,9 +4,11 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=vendor-migration vendor=ciscoasa | fix to avoid none object to read isGroup()
 
 GENERAL:
 - update dynamic content to Device App-ID version: 8708-8036
+- improvements for PHP8.2 - deprecated variable declaration | function utf8_encode()
 
 
 2.1.3 (20230511)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.1.4
 UTIL:
+* type=vendor-migration | improve output if arguments are missing
 
 BUGFIX:
 * type=vendor-migration vendor=ciscoasa | fix to avoid none object to read isGroup()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,15 @@
 CHANGELOG
 
-2.1.3
+2.1.4
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+- update dynamic content to Device App-ID version: 8708-8036
+
+
+2.1.3 (20230511)
 UTIL:
 * type=rule ruletype=nat | introduce 'filter=(natruletype is XYZ)' - 'ipv4', 'nat64', 'nptv6'
 * type=rule ruletype=nat | introduce 'filter=(snatinterface is.set)'

--- a/lib/container-classes/ObjRuleContainer.php
+++ b/lib/container-classes/ObjRuleContainer.php
@@ -34,6 +34,8 @@ class ObjRuleContainer
 
     public $o = array();
 
+    protected $fasthashcomp;
+
     public function count()
     {
         return count($this->o);

--- a/lib/container-classes/ServiceRuleContainer.php
+++ b/lib/container-classes/ServiceRuleContainer.php
@@ -36,6 +36,7 @@ class ServiceRuleContainer extends ObjRuleContainer
     private $appDef = FALSE;
     private $wrongService = FALSE;
 
+    protected $fasthashcomp;
 
     public function __construct($owner)
     {

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -172,7 +172,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 3;
+    private static $library_version_bugfix = 4;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/trait/ObjectWithDescription.php
+++ b/lib/misc-classes/trait/ObjectWithDescription.php
@@ -58,7 +58,8 @@ trait ObjectWithDescription
         }
         else
         {
-            $newDescription = utf8_encode($newDescription);
+            #$newDescription = utf8_encode($newDescription);
+            $newDescription = mb_convert_encoding($newDescription, 'UTF-8', 'ISO-8859-1');
             if( $this->_description == $newDescription )
                 return FALSE;
             $this->_description = $newDescription;

--- a/lib/misc-classes/trait/XmlConvertible.php
+++ b/lib/misc-classes/trait/XmlConvertible.php
@@ -25,6 +25,10 @@ trait XmlConvertible
     /** @var DOMElement|null $xmlroot */
     public $xmlroot = null;
 
+    protected $warning;
+    protected $error;
+    protected $info;
+
     function &getXmlText_inline()
     {
         return DH::dom_to_xml($this->xmlroot, -1, FALSE);

--- a/lib/network-classes/VirtualRouter.php
+++ b/lib/network-classes/VirtualRouter.php
@@ -35,6 +35,9 @@ class VirtualRouter
 
     protected $xmlroot_protocol = false;
 
+    protected $fastMemToIndex;
+    protected $fastNameToIndex;
+
     /**
      * @param $name string
      * @param $owner VirtualRouterStore

--- a/lib/network-classes/VirtualRouterStore.php
+++ b/lib/network-classes/VirtualRouterStore.php
@@ -31,6 +31,10 @@ class VirtualRouterStore extends ObjStore
 
     public static $childn = 'VirtualRouter';
 
+    protected $fastMemToIndex;
+    protected $fastNameToIndex;
+
+
     public function __construct($name, $owner)
     {
         $this->name = $name;

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -59,6 +59,9 @@ class Address
 
     public $_ip4Map = null;
 
+    public $ancestor;
+
+
     /**
      * you should not need this one for normal use
      * @param string $name

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -46,7 +46,7 @@ class AddressGroup
     public $tags;
 
     public $filter;
-
+    public $ancestor;
 
     /**
      * Constructor for AddressGroup. There is little chance that you will ever need that. Look at AddressStore if you want to create an AddressGroup

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -35,7 +35,7 @@ class Service
     protected $_timewait_timeout;
 
     public $migrated;
-
+    public $ancestor;
 
     /** @var null|DOMElement */
     public $protocolRoot = null;

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -34,6 +34,9 @@ class Service
     protected $_halfclose_timeout;
     protected $_timewait_timeout;
 
+    public $migrated;
+
+
     /** @var null|DOMElement */
     public $protocolRoot = null;
 

--- a/lib/object-classes/ServiceGroup.php
+++ b/lib/object-classes/ServiceGroup.php
@@ -35,6 +35,7 @@ class ServiceGroup
     /** @var TagRuleContainer */
     public $tags;
 
+    public $ancestor;
 
     public function __construct($name, $owner = null, $fromTemplateXml = FALSE)
     {

--- a/lib/rule-classes/RuleWithGroupTag.php
+++ b/lib/rule-classes/RuleWithGroupTag.php
@@ -109,7 +109,8 @@ trait RuleWithGroupTag
         }
         else
         {
-            $newGroupTag = utf8_encode($newGroupTag);
+            #$newGroupTag = utf8_encode($newGroupTag);
+            $newGroupTag = mb_convert_encoding($newGroupTag, 'UTF-8', 'ISO-8859-1');
             if( is_object( $this->grouptag ) && $this->grouptag->name() == $newGroupTag )
                 return FALSE;
 

--- a/lib/rule-classes/RuleWithSchedule.php
+++ b/lib/rule-classes/RuleWithSchedule.php
@@ -97,7 +97,8 @@ trait RuleWithSchedule
         }
         else
         {
-            $newSchedule = utf8_encode($newSchedule);
+            #$newSchedule = utf8_encode($newSchedule);
+            $newSchedule = mb_convert_encoding($newSchedule, 'UTF-8', 'ISO-8859-1');
             if( is_object( $this->schedule ) && $this->schedule->name() == $newSchedule )
                 return FALSE;
 

--- a/lib/rule-classes/RuleWithUserID.php
+++ b/lib/rule-classes/RuleWithUserID.php
@@ -143,7 +143,8 @@ class RuleWithUserID extends Rule
     {
         $tmpRoot = DH::findFirstElementOrCreate('source-user', $this->xmlroot);
 
-        $newUser = utf8_encode($newUser);
+        #$newUser = utf8_encode($newUser);
+        $newUser = mb_convert_encoding($newUser, 'UTF-8', 'ISO-8859-1');
         if( in_array($newUser, $this->_users, TRUE) )
             return FALSE;
 
@@ -158,7 +159,8 @@ class RuleWithUserID extends Rule
     {
         $tmpRoot = DH::findFirstElementOrCreate('source-user', $this->xmlroot);
 
-        $newUser = utf8_encode($newUser);
+        #$newUser = utf8_encode($newUser);
+        $newUser = mb_convert_encoding($newUser, 'UTF-8', 'ISO-8859-1');
         if (($key = array_search($newUser, $this->_users)) !== FALSE) {
             unset($this->_users[$key]);
         }

--- a/lib/rule-classes/SecurityRule.php
+++ b/lib/rule-classes/SecurityRule.php
@@ -38,6 +38,18 @@ class SecurityRule extends RuleWithUserID
     /** @var string[] */
     protected $_urlCategories = array();
 
+
+    public $appsToAdd;
+    public $appConvertedRule;
+
+    public $alreadyMerged;
+
+    public $indexPosition;
+    public $mergeHash;
+    public $serial;
+
+
+
     /**
      * @var UrlCategoryRuleContainer
      */

--- a/migration/parser/CISCO/CISCOnetwork.php
+++ b/migration/parser/CISCO/CISCOnetwork.php
@@ -290,8 +290,8 @@ trait CISCOnetwork
             if( preg_match("/^interface /i", $names_line) )
             {
                 $isInterface = TRUE;
-                $this->dataI = preg_split('/\s/', $names_line, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-                $interfaceName = $this->dataI[1];
+                $dataI = preg_split('/\s/', $names_line, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+                $interfaceName = $dataI[1];
 
                 /*
                 if( preg_match("/^Management/i", $interfaceName) )

--- a/migration/parser/CISCO/CISCOsecurityrules.php
+++ b/migration/parser/CISCO/CISCOsecurityrules.php
@@ -1011,9 +1011,13 @@ trait CISCOsecurityrules
                                             $tmp_service = $this->sub->serviceStore->find($tmp_protocol . "-" . $value);
                                             if( $tmp_service === null )
                                             {
-                                                if( $print )
-                                                    print "     * create service: " . $tmp_protocol . "-" . $value . "\n";
-                                                $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                $tmp_service = $this->sub->serviceStore->find($value . "_" . $tmp_protocol);
+                                                if( $tmp_service === null )
+                                                {
+                                                    if( $print )
+                                                        print "     * create service: " . $tmp_protocol . "-" . $value . "\n";
+                                                    $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                }
                                             }
                                         }
                                         if( $tmp_service !== null )
@@ -1035,9 +1039,13 @@ trait CISCOsecurityrules
                                                 #mwarning( "servicgroup found and protocol is: ".$tmp_protocol );
                                                 if( $tmp_service === null )
                                                 {
-                                                    if( $print )
-                                                        print "     * create service: " . $tmp_protocol . "-" . $value . "\n";
-                                                    $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                    $tmp_service = $this->sub->serviceStore->find($value . "_" . $tmp_protocol);
+                                                    if( $tmp_service === null )
+                                                    {
+                                                        if( $print )
+                                                            print "     * create service: " . $tmp_protocol . "-" . $value . "\n";
+                                                        $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                    }
                                                 }
                                             }
                                             elseif( $tmp_service === null )
@@ -1222,9 +1230,13 @@ trait CISCOsecurityrules
                                             $tmp_service = $this->sub->serviceStore->find($tmp_protocol . "-" . $value);
                                             if( $tmp_service === null )
                                             {
-                                                if( $print )
-                                                    print "   * create service " . $tmp_protocol . "-" . $value . "\n";
-                                                $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                $tmp_service = $this->sub->serviceStore->find($value . "_" . $tmp_protocol);
+                                                if( $tmp_service === null )
+                                                {
+                                                    if( $print )
+                                                        print "     * create service: " . $tmp_protocol . "-" . $value . "\n";
+                                                    $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
+                                                }
                                             }
                                             if( $print )
                                                 print "   * add service: " . $tmp_service->name() . "\n";

--- a/migration/parser/CISCO/CISCOsecurityrules.php
+++ b/migration/parser/CISCO/CISCOsecurityrules.php
@@ -999,16 +999,15 @@ trait CISCOsecurityrules
                                         if( $tmp_service === null )
                                             $tmp_service = $this->sub->serviceStore->find("tmp-".$value);
 
+                                        if( $tmp_protocol == "" || $tmp_protocol == "ip" )
+                                        {
+                                            //Todo: SVEN 20200203
+                                            //if IP then create tcp and udp, plus a service group where both are in
+                                            $tmp_protocol = "tcp";
+                                        }
+
                                         if( $tmp_service === null )
                                         {
-                                            if( $tmp_protocol == "" || $tmp_protocol == "ip" )
-                                            {
-                                                //Todo: SVEN 20200203
-                                                //if IP then create tcp and udp, plus a service group where both are in
-                                                $tmp_protocol = "tcp";
-                                            }
-
-
                                             $tmp_service = $this->sub->serviceStore->find($tmp_protocol . "-" . $value);
                                             if( $tmp_service === null )
                                             {
@@ -1022,12 +1021,12 @@ trait CISCOsecurityrules
                                             if( $tmp_service->isGroup() )
                                                 $tmp_service = $this->sub->serviceStore->find($value."_".$tmp_protocol);
 
-                                            if( !$tmp_service->isGroup() && $tmp_protocol != "" && $tmp_service->protocol() != $tmp_protocol )
+                                            if( $tmp_service !== null || (!$tmp_service->isGroup() && $tmp_protocol != "" && $tmp_service->protocol() != $tmp_protocol) )
                                             {
                                                 if( !is_numeric($value) )
                                                 {
                                                     $tmp_service2 = $this->sub->serviceStore->find($value);
-                                                    if( $tmp_service2 !== null )
+                                                    if( $tmp_service2 !== null && !$tmp_service2->isGroup() )
                                                     {
                                                         $value = $tmp_service2->getDestPort();
                                                     }
@@ -1041,6 +1040,9 @@ trait CISCOsecurityrules
                                                     $tmp_service = $this->sub->serviceStore->newService($tmp_protocol . "-" . $value, $tmp_protocol, $value);
                                                 }
                                             }
+                                            elseif( $tmp_service === null )
+                                                derr( "NULL: object not found: value: ".$value." prot: ".$tmp_protocol." which is searching for name: ".$value."_".$tmp_protocol );
+
                                             if( $print )
                                                 print "    * add service - service object: " . $tmp_service->name() . "\n";
                                             $tmp_rule->services->add($tmp_service);

--- a/migration/parser/lib/CONVERTER.php
+++ b/migration/parser/lib/CONVERTER.php
@@ -713,11 +713,11 @@ class CONVERTER extends UTIL
         #$this->vendor = $_vendor;
 
         if( empty($this->configInput) )
-            derr("variable: 'IN=' is not set!");
+            derr("argument: 'IN=' is not set!", null, False);
         elseif( empty($this->configOutput) )
-            derr("variable: 'OUT=' is not set!");
+            derr("argument: 'OUT=' is not set!", null, False);
         elseif( empty($this->configFile) )
-            derr("variable: 'FILE=' is not set!");
+            derr("argument: 'FILE=' is not set!", null, False);
 
 
         self::global_start();

--- a/utils/common/RuleCallContext.php
+++ b/utils/common/RuleCallContext.php
@@ -25,6 +25,8 @@ class RuleCallContext extends CallContext
     public static $commonActionFunctions = array();
     public static $supportedActions = array();
 
+    public $fields;
+
     static public function prepareSupportedActions()
     {
         $tmpArgs = array();

--- a/utils/develop/ike.php
+++ b/utils/develop/ike.php
@@ -43,16 +43,17 @@ function display_usage_and_exit($shortMessage = FALSE)
         global $supportedArguments;
 
         ksort($supportedArguments);
-        $text = "";
+
         foreach( $supportedArguments as &$arg )
         {
+            $text = "";
             $text .= " - " . PH::boldText($arg['niceName']);
             if( isset($arg['argDesc']) )
                 $text .= '=' . $arg['argDesc'];
             //."=";
             if( isset($arg['shortHelp']) )
                 $text .= "\n     " . $arg['shortHelp'];
-            PH::print_stdout( $text);
+            PH::print_stdout( $text."\n");
         }
 
         PH::print_stdout();

--- a/utils/lib/RULEMERGER.php
+++ b/utils/lib/RULEMERGER.php
@@ -47,6 +47,11 @@ class RULEMERGER extends UTIL
     public $exportcsv = FALSE;
     public $exportcsvFile = null;
 
+
+    public $context;
+    public $action;
+
+
     public function utilStart()
     {
         $this->usageMsg = PH::boldText("USAGE: ") . "php " . basename(__FILE__) . " in=inputfile.xml|api://... location=shared|sub [out=outputfile.xml]" .

--- a/utils/lib/logWriter.php
+++ b/utils/lib/logWriter.php
@@ -43,6 +43,8 @@ class logWriter
 
     protected $util = null;
 
+    protected $params;
+
     /**
      * Class constructor
      * @param string $log_file - path and filename of log


### PR DESCRIPTION
## Description

UTIL:
* type=vendor-migration | improve output if arguments are missing

BUGFIX:
* type=vendor-migration vendor=ciscoasa | fix to avoid none object to read isGroup()
* type=vendor-migration vendor=ciscoasa | bugfix for creating service - to not add e.g. tacacs as service port

GENERAL:
- update dynamic content to Device App-ID version: 8708-8036
- improvements for PHP8.2 - deprecated variable declaration | function utf8_encode()