### PR TITLE
introduce version 2.1.6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ BUGFIX:
 * class PanoramaConf | bugfix for type=device actions=devicegroup-create:NAME,parent - parentDG was not set correctly
 * type=address/service actions=move:DG | bugfix - add additional validation for move to upper/lower level DG - if another object with same name will change behaviour
 * f5_bigIP | bugfix for ServiceGroup which can not handle Description based on PAN-OS
+* type=addressgroup-/servicegroup-merger | bugfix - extend validation to not merge/move objects if not same members
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 
 BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol
+* type=address/service-merger | bugfix - extend validation if objects can be merged
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.5
+2.1.6
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.5 (20230516)
 UTIL:
 * develop utility | introduce rule_compare_src_dst_srv_summary
 * type=device | introduce actions=template-clone:NEWtemplateNAME 'filter=(name eq OLDtemplateNAME'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ BUGFIX:
 * type=xml-issue | bugfix - wrong XML node variable used for application Node deletion
 
 GENERAL:
+* dynamic content updated to version: 8713-8071
 
 
 2.1.5 (20230516)
@@ -32,7 +33,7 @@ BUGFIX:
 * type=address | bugfix for filter=(value string.XYZ ) if Object of type Region is hit
 * type=rule-merger | bugfix if panoramapostrules and no rule are set for exportcsv
 * class UrlCategoryRuleContainer | bugfix for PHP 8.1 - variable not set
-* type=address-merger | picketObject from upperlevel of type TMP is not possible - to not merge
+* type=address-merger | picketObject from upperlevel of type TMP is not possible - do not merge
 * general - different classes - reordering reading of region objects - as these are taking precedence compare to address-group and address
 * type=service-merger | bugfix to not delete object if merge is not possible - rare condition related to object overwritten at lower level
 * type=address-/service-merger | bugfix to NOT replace an overwritten object with different value with an object from upper level

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ BUGFIX:
 * type=address/service-merger | bugfix - extend validation if objects can be merged
 * class PanoramaConf | bugfix for type=device actions=devicegroup-create:NAME,parent - parentDG was not set correctly
 * type=address/service actions=move:DG | bugfix - add additional validation for move to upper/lower level DG - if another object with same name will change behaviour
+* f5_bigIP | bugfix for ServiceGroup which can not handle Description based on PAN-OS
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol
 * type=address/service-merger | bugfix - extend validation if objects can be merged
 * class PanoramaConf | bugfix for type=device actions=devicegroup-create:NAME,parent - parentDG was not set correctly
+* type=address/service actions=move:DG | bugfix - add additional validation for move to upper/lower level DG - if another object with same name will change behaviour
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.1.6
 UTIL:
+* type=rule-compare | improve output to also fit for argument 'shadow-json'
 
 BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.1.6
 UTIL:
 * type=rule-compare | improve output to also fit for argument 'shadow-json'
+* class Address/ServiceCommon | improve text output for type=address-/service-merger
 
 BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ UTIL:
 BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol
 * type=address/service-merger | bugfix - extend validation if objects can be merged
+* class PanoramaConf | bugfix for type=device actions=devicegroup-create:NAME,parent - parentDG was not set correctly
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=service-merger | bugfix for merging objects which are overwritten but with different protocol
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ BUGFIX:
 * type=address/service actions=move:DG | bugfix - add additional validation for move to upper/lower level DG - if another object with same name will change behaviour
 * f5_bigIP | bugfix for ServiceGroup which can not handle Description based on PAN-OS
 * type=addressgroup-/servicegroup-merger | bugfix - extend validation to not merge/move objects if not same members
+* type=xml-issue | bugfix - wrong XML node variable used for application Node deletion
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=rule-compare | improve output to also fit for argument 'shadow-json'
 * class Address/ServiceCommon | improve text output for type=address-/service-merger
+* type=upload | extend to copy XML node from argument in= to argument out= - first version focus on Device-Group
 
 BUGFIX:
 * type=service-merger | bugfix for merging objects which are overwritten but with different protocol

--- a/lib/device-and-system-classes/PanoramaConf.php
+++ b/lib/device-and-system-classes/PanoramaConf.php
@@ -2092,10 +2092,19 @@ class PanoramaConf
             else
                 $dgMetaDataNode = DH::findXPathSingleEntryOrDie('/config/readonly/dg-meta-data/dg-info', $this->xmlroot);
 
+            $parentXMLnode = "";
+            if( $parentDGname !== null )
+            {
+                $parentDG = $this->findDeviceGroup( $parentDGname );
+                if( $parentDG === null )
+                    mwarning("DeviceGroup '$name' has DeviceGroup '{$parentDGname}' listed as parent but it cannot be found in XML");
+                else
+                    $parentXMLnode = "<parent-dg>".$parentDGname."</parent-dg>";
+            }
             if( $this->version >= 80 )
-                $newXmlNode = DH::importXmlStringOrDie($this->xmldoc, "<entry name=\"{$name}\"><id>{$dgMaxID}</id></entry>");
+                $newXmlNode = DH::importXmlStringOrDie($this->xmldoc, "<entry name=\"{$name}\"><id>{$dgMaxID}</id>".$parentXMLnode."</entry>");
             else
-                $newXmlNode = DH::importXmlStringOrDie($this->xmldoc, "<entry name=\"{$name}\"><dg-id>{$dgMaxID}</dg-id></entry>");
+                $newXmlNode = DH::importXmlStringOrDie($this->xmldoc, "<entry name=\"{$name}\"><dg-id>{$dgMaxID}</dg-id>".$parentXMLnode."</entry>");
 
             $dgMetaDataNode->appendChild($newXmlNode);
         }

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -172,7 +172,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 5;
+    private static $library_version_bugfix = 6;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -547,11 +547,11 @@ trait AddressCommon
 
                 #template <tunnel><units><entry name="tunnel.1"><ip>
 
-                PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName());
+                #PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName());
                 $tmp_addr = $tmp_store->find( $withObject->name() );
                 if( $tmp_addr === null )
                 {
-                    PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName()." parentStore");
+                    #PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName()." parentStore");
                     $tmp_addr = $tmp_store->parentCentralStore->find( $withObject->name() );
                 }
 

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -514,7 +514,7 @@ trait AddressCommon
                     }
                     else
                     {
-                        PH::print_stdout( "- SKIP: not possible due to different object type" );
+                        PH::print_stdout( "- SKIP: not possible due to different object type: '".$this->name()."-".$this->type()."' <=> '".$withObject->name()."-".$withObject->type()."'" );
                         continue;
                     }
                 }
@@ -547,13 +547,18 @@ trait AddressCommon
 
                 #template <tunnel><units><entry name="tunnel.1"><ip>
 
+                PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName());
                 $tmp_addr = $tmp_store->find( $withObject->name() );
                 if( $tmp_addr === null )
+                {
+                    PH::print_stdout("search object: ".$withObject->name()." in store: ".$tmp_store->storeName()." parentStore");
                     $tmp_addr = $tmp_store->parentCentralStore->find( $withObject->name() );
+                }
+
 
                 if( !$tmp_addr->isAddress() )
                 {
-                    PH::print_stdout( "- SKIP: not possible due to different object type" );
+                    PH::print_stdout( "- SKIP: not possible due to different object type. object is AddressGroup" );
                     $success = false;
                     continue;
                 }

--- a/lib/object-classes/trait/ServiceCommon.php
+++ b/lib/object-classes/trait/ServiceCommon.php
@@ -335,9 +335,10 @@ trait ServiceCommon
 
             if( ($this->isService() && $withObject->isService()) )
             {
-                if( $this->type !== $withObject->type )
+                if( $this->protocol() !== $withObject->protocol() )
                 {
                     PH::print_stdout("- SKIP: not possible due to different object type");
+                    $success = false;
                     continue;
                 }
 
@@ -362,10 +363,10 @@ trait ServiceCommon
                     continue;
                 }
 
-                if( $withObject->getDestPort() !== $tmp_addr->getDestPort() || $withObject->getSourcePort() !== $tmp_addr->getSourcePort()  )
+                if( $withObject->getDestPort() !== $tmp_addr->getDestPort() || $withObject->getSourcePort() !== $tmp_addr->getSourcePort() || $withObject->protocol() !== $tmp_addr->protocol()  )
                 {
                     PH::print_stdout( "- SKIP: not possible to replace due to different value: {$objectRef->toString()}" );
-                    PH::print_stdout( " - '".$withObject->getDestPort()."[".$withObject->getSourcePort()."]"."' | '".$tmp_addr->getDestPort()."[".$tmp_addr->getSourcePort()."]"."'" );
+                    PH::print_stdout( " - '".$withObject->protocol()."-".$withObject->getDestPort()."[".$withObject->getSourcePort()."]"."' | '".$tmp_addr->protocol()."-".$tmp_addr->getDestPort()."[".$tmp_addr->getSourcePort()."]"."'" );
                     $success = false;
                     continue;
                 }

--- a/lib/object-classes/trait/ServiceCommon.php
+++ b/lib/object-classes/trait/ServiceCommon.php
@@ -337,7 +337,7 @@ trait ServiceCommon
             {
                 if( $this->protocol() !== $withObject->protocol() )
                 {
-                    PH::print_stdout("- SKIP: not possible due to different object type");
+                    PH::print_stdout("- SKIP: not possible due to different object type: '".$this->name()." - ".$this->protocol()."' <=> '".$withObject->name()." - ".$withObject->protocol()."'" );
                     $success = false;
                     continue;
                 }
@@ -358,7 +358,7 @@ trait ServiceCommon
 
                 if( !$tmp_addr->isService() )
                 {
-                    PH::print_stdout( "- SKIP: not possible due to different object type" );
+                    PH::print_stdout( "- SKIP: not possible due to different object type. object is not Service" );
                     $success = false;
                     continue;
                 }

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -288,45 +288,55 @@ DeviceCallContext::$supportedActions['displayreferences'] = array(
 
 DeviceCallContext::$supportedActions['DeviceGroup-create'] = array(
     'name' => 'devicegroup-create',
+    'GlobalInitFunction' => function (DeviceCallContext $context) {
+        $context->first = true;
+    },
     'MainFunction' => function (DeviceCallContext $context) {
     },
     'GlobalFinishFunction' => function (DeviceCallContext $context) {
-        $dgName = $context->arguments['name'];
-        $parentDG = $context->arguments['parentdg'];
-
-        $pan = $context->subSystem;
-
-        if( !$pan->isPanorama() )
-            derr("only supported on Panorama config");
-
-        if( $parentDG != 'null' )
+        if( $context->first )
         {
-            $tmp_parentdg = $pan->findDeviceGroup($parentDG);
-            if( $tmp_parentdg === null )
+
+
+            $dgName = $context->arguments['name'];
+            $parentDG = $context->arguments['parentdg'];
+
+            $pan = $context->subSystem;
+
+            if( !$pan->isPanorama() )
+                derr("only supported on Panorama config");
+
+            if( $parentDG != 'null' )
             {
-                $string = "parentDG set with '" . $parentDG . "' but not found on this config";
-                PH::ACTIONstatus($context, "SKIPPED", $string);
-                $parentDG = null;
+                $tmp_parentdg = $pan->findDeviceGroup($parentDG);
+                if( $tmp_parentdg === null )
+                {
+                    $string = "parentDG set with '" . $parentDG . "' but not found on this config";
+                    PH::ACTIONstatus($context, "SKIPPED", $string);
+                    $parentDG = null;
+                }
             }
-        }
 
-        $tmp_dg = $pan->findDeviceGroup($dgName);
-        if( $tmp_dg === null )
-        {
-            $string = "create DeviceGroup: " . $dgName;
-            #PH::ACTIONlog($context, $string);
-            if( $parentDG === 'null' )
-                $parentDG = null;
+            $tmp_dg = $pan->findDeviceGroup($dgName);
+            if( $tmp_dg === null )
+            {
+                $string = "create DeviceGroup: " . $dgName;
+                #PH::ACTIONlog($context, $string);
+                if( $parentDG === 'null' )
+                    $parentDG = null;
 
-            $dg = $pan->createDeviceGroup($dgName, $parentDG);
+                $dg = $pan->createDeviceGroup($dgName, $parentDG);
 
-            if( $context->isAPI )
-                $dg->API_sync();
-        }
-        else
-        {
-            $string = "DeviceGroup with name: " . $dgName . " already available!";
-            PH::ACTIONlog( $context, $string );
+                if( $context->isAPI )
+                    $dg->API_sync();
+            }
+            else
+            {
+                $string = "DeviceGroup with name: " . $dgName . " already available!";
+                PH::ACTIONlog($context, $string);
+            }
+
+            $context->first = false;
         }
     },
     'args' => array(

--- a/utils/develop/migration/f5_bigip.php
+++ b/utils/develop/migration/f5_bigip.php
@@ -301,7 +301,12 @@ foreach ($file_content as $line => $names_line) {
                 $description=$desc[1];
             }
 
-            $tmp_servicegroup->setDescription( $description );
+            if( $tmp_servicegroup->isGroup() )
+            {
+                mwarning("PANOS does not support description on ServiceGroup!!!");
+            }
+            else
+                $tmp_servicegroup->setDescription( $description );
             continue(1);
         }
         if ($objectService){

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -1517,6 +1517,7 @@ var subjectObject =
             },
             "devicegroup-create": {
                 "name": "devicegroup-create",
+                "GlobalInitFunction": {},
                 "MainFunction": {},
                 "GlobalFinishFunction": {},
                 "args": {

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -2396,9 +2396,11 @@ class MERGER extends UTIL
                             $exitObject = null;
                             foreach( $child_NamehashMap[ $pickedObject->name() ] as $obj )
                             {
+                                /** @var Service $obj */
                                 if( !$obj->dstPortMapping()->equals($pickedObject->dstPortMapping())
                                     || !$obj->srcPortMapping()->equals($pickedObject->srcPortMapping())
                                     || $obj->getOverride() != $pickedObject->getOverride()
+                                    || $obj->protocol() != $pickedObject->protocol()
                                 )
                                 {
                                     $exit = true;
@@ -2773,8 +2775,19 @@ class MERGER extends UTIL
 
     function servicePickedObjectValidation( $index, $object, $pickedObject )
     {
+        /** @var Service $object */
+        /** @var Service $pickedObject */
+
         $skipped = false;
-        if( !$object->srcPortMapping()->equals($pickedObject->srcPortMapping()) && $this->dupAlg == 'samedstsrcports' )
+        if( $object->protocol() != $pickedObject->protocol() )
+        {
+            $text = "    - object '{$object->name()}' cannot be merged because of different service protocol";
+            $text .="  object protocol value: " . $object->protocol() . " | pickedObject protocol value: " . $pickedObject->protocol();
+            PH::print_stdout( $text );
+            $this->skippedObject( $index, $object, $pickedObject);
+            $skipped = true;
+        }
+        elseif( !$object->srcPortMapping()->equals($pickedObject->srcPortMapping()) && $this->dupAlg == 'samedstsrcports' )
         {
             $text = "    - object '{$object->name()}' cannot be merged because of different SRC port information";
             $text .= "  object value: " . $object->srcPortMapping()->mappingToText() . " | pickedObject value: " . $pickedObject->srcPortMapping()->mappingToText();
@@ -2790,6 +2803,7 @@ class MERGER extends UTIL
             $this->skippedObject( $index, $object, $pickedObject);
             $skipped = true;
         }
+
         return $skipped;
     }
 

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -227,10 +227,16 @@ class RULE_COMPARE extends UTIL
             PH::print_stdout();
             $text = "NO Rule diff for SOURCE / DESTINATION / SERVICE";
             PH::print_stdout( PH::boldText($text) );
-            $finalArray[] = $text;
+            $finalArray['info'] = $text;
             PH::print_stdout();
             PH::print_stdout();
         }
+        else
+        {
+            $text = "Rule diff available | check details";
+            $finalArray['info'] = $text;
+        }
+
 
 
         PH::$JSON_TMP = array();
@@ -307,7 +313,8 @@ class RULE_COMPARE extends UTIL
                 PH::print_stdout("    - ".$entry);
                 $compareArray['file1'][] = $entry;
             }
-
+            if( empty($tmp1) )
+                $compareArray['file1'] = array();
         }
 
         if( !empty($tmp2) || !empty($tmp1) )
@@ -319,12 +326,15 @@ class RULE_COMPARE extends UTIL
                 PH::print_stdout("    - ".$entry);
                 $compareArray['file2'][] = $entry;
             }
-
+            if( empty($tmp2) )
+                $compareArray['file2'] = array();
         }
 
         if( empty($tmp1) && empty($tmp2) )
         {
             PH::print_stdout("   only the order of information was different");
+            $compareArray['file1'] = array();
+            $compareArray['file2'] = array();
         }
     }
 }

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -135,7 +135,7 @@ class RULE_COMPARE extends UTIL
                 derr("problems");
         }
 
-
+        $finalArray = array();
         foreach( $array1[$confType] as $key1 => $tmpArray )
         {
             if( !isset($tmpArray['sub']) )
@@ -190,26 +190,33 @@ class RULE_COMPARE extends UTIL
                     $ruleDiff = TRUE;
 
                     PH::print_stdout("--------------------------------------------------");
-                    PH::print_stdout("SUB: '" . $subName . "' | Rule diff found: " . $key);
+                    PH::print_stdout("SUB: '" . $subName . "' | Rule diff found: '" . PH::boldText($key)."'");
+                    $finalArray[$subName][$key] = array();
                     if( !empty($diff_src) )
                     {
-                        PH::print_stdout( PH::boldText(" - source") );
-                        PH::print_stdout();
-                        $this->printArray($src1, $src2);
+                        $keyword = "source";
+                        $compareArray = array();
+                        PH::print_stdout( PH::boldText("  ".$keyword) );
+                        $this->printArray($src1, $src2, $compareArray);
+                        $finalArray[$subName][$key][$keyword] = $compareArray;
                     }
 
                     if( !empty($diff_dst) )
                     {
-                        PH::print_stdout( PH::boldText(" - destination") );
-                        PH::print_stdout();
-                        $this->printArray($dst1, $dst2);
+                        $keyword = "destination";
+                        $compareArray = array();
+                        PH::print_stdout( PH::boldText("  ".$keyword) );
+                        $this->printArray($dst1, $dst2, $compareArray);
+                        $finalArray[$subName][$key][$keyword] = $compareArray;
                     }
 
                     if( !empty($diff_srv) )
                     {
-                        PH::print_stdout( PH::boldText(" - service") );
-                        PH::print_stdout();
-                        $this->printArray($srv1, $srv2);
+                        $keyword = "service";
+                        $compareArray = array();
+                        PH::print_stdout( PH::boldText("  ".$keyword) );
+                        $this->printArray($srv1, $srv2, $compareArray);
+                        $finalArray[$subName][$key][$keyword] = $compareArray;
                     }
                 }
             }
@@ -218,11 +225,17 @@ class RULE_COMPARE extends UTIL
         {
             PH::print_stdout();
             PH::print_stdout();
-            PH::print_stdout("NO Rule diff for SOURCE / DESTINATION / SERVICE");
+            $text = "NO Rule diff for SOURCE / DESTINATION / SERVICE";
+            PH::print_stdout( PH::boldText($text) );
+            $finalArray[] = $text;
             PH::print_stdout();
             PH::print_stdout();
         }
 
+
+        PH::$JSON_TMP = array();
+        if( PH::$shadow_json )
+            PH::$JSON_OUT['rule-compare'] = $finalArray;
 
         //cleanup
         unlink($json_file1_name);
@@ -273,22 +286,45 @@ class RULE_COMPARE extends UTIL
     {
         foreach( $array1 as $key => $entry )
         {
-            if( isset( $array2[$key] ) )
+            if( in_array($entry, $array2) )
                 unset($array1[$key]);
         }
 
         return $array1;
     }
 
-    function printArray($array1, $array2)
+    function printArray($array1, $array2, &$compareArray)
     {
-        PH::print_stdout("  - file1");
         $tmp1 = $this->checkArrayClean($array1, $array2);
-        print_r($tmp1);
-
-
-        PH::print_stdout("   - file2");
         $tmp2 = $this->checkArrayClean($array2, $array1);
-        print_r($tmp2);
+
+        if( !empty($tmp1) || !empty($tmp2))
+        {
+            PH::print_stdout("  * file1");
+            #print_r($tmp1);
+            foreach( $tmp1 as $entry )
+            {
+                PH::print_stdout("    - ".$entry);
+                $compareArray['file1'][] = $entry;
+            }
+
+        }
+
+        if( !empty($tmp2) || !empty($tmp1) )
+        {
+            PH::print_stdout("   * file2");
+            #print_r($tmp2);
+            foreach( $tmp2 as $entry )
+            {
+                PH::print_stdout("    - ".$entry);
+                $compareArray['file2'][] = $entry;
+            }
+
+        }
+
+        if( empty($tmp1) && empty($tmp2) )
+        {
+            PH::print_stdout("   only the order of information was different");
+        }
     }
 }

--- a/utils/lib/XMLISSUE.php
+++ b/utils/lib/XMLISSUE.php
@@ -1049,7 +1049,7 @@ class XMLISSUE extends UTIL
                                         if( isset($secRuleApplication[$objectApplicationName]) )
                                         {
                                             $text = "     - Secrule: ".$objectName." has same application defined twice: ".$objectApplicationName;
-                                            $objectNode_applications->removeChild($objectNode_applications);
+                                            $objectNode_applications->removeChild($objectApplication);
                                             $text .=PH::boldText(" (removed)")."\n";
                                             PH::print_stdout( $text );
                                             $fixedSecRuleApplicationObjects++;

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -1516,6 +1516,7 @@
             },
             "devicegroup-create": {
                 "name": "devicegroup-create",
+                "GlobalInitFunction": {},
                 "MainFunction": {},
                 "GlobalFinishFunction": {},
                 "args": {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

UTIL:
* type=rule-compare | improve output to also fit for argument 'shadow-json'
* class Address/ServiceCommon | improve text output for type=address-/service-merger
* type=upload | extend to copy XML node from argument in= to argument out= - first version focus on Device-Group

BUGFIX:
* type=service-merger | bugfix for merging objects which are overwritten but with different protocol
* type=address/service-merger | bugfix - extend validation if objects can be merged
* class PanoramaConf | bugfix for type=device actions=devicegroup-create:NAME,parent - parentDG was not set correctly
* type=address/service actions=move:DG | bugfix - add additional validation for move to upper/lower level DG - if another object with same name will change behaviour
* f5_bigIP | bugfix for ServiceGroup which can not handle Description based on PAN-OS
* type=addressgroup-/servicegroup-merger | bugfix - extend validation to not merge/move objects if not same members
* type=xml-issue | bugfix - wrong XML node variable used for application Node deletion

GENERAL:
* dynamic content updated to version: 8713-8071