### PR TITLE
version 2.1.7

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.6
+2.1.7
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.6 (20230525)
 UTIL:
 * type=rule-compare | improve output to also fit for argument 'shadow-json'
 * class Address/ServiceCommon | improve text output for type=address-/service-merger

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,9 +2,11 @@ CHANGELOG
 
 2.1.7
 UTIL:
+* type=xml-issue | extend for duplicate search on readonly device-group
 
 BUGFIX:
 * type=address-/service-merger | bugfix if two childDGs are having same object name and value - but somewhere in parentDG hierarchy below the target location DG planned for creating merged object - object with different value is available
+* type=tag-merger | bugfix to exclude only these tag with different value (different color) - and merge with same value
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=address-/service-merger | bugfix if two childDGs are having same object name and value - but somewhere in parentDG hierarchy below the target location DG planned for creating merged object - object with different value is available
 
 GENERAL:
 

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -172,7 +172,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 6;
+    private static $library_version_bugfix = 7;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/object-classes/Tag.php
+++ b/lib/object-classes/Tag.php
@@ -140,6 +140,8 @@ class Tag
     static public $replacewith1 = "/{";
     static public $replacewith2 = "/}";
 
+    public $ancestor;
+
     /**
      * @param string $name
      * @param TagStore|null $owner

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -3174,7 +3174,7 @@ class MERGER extends UTIL
                         foreach( $child_NamehashMap[ $pickedObject->name() ] as $obj )
                         {
                             //Todo: validate if this is correct; expectation is not same color swaschkut 20230525
-                            if( $obj->sameValue($pickedObject) ) //same color
+                            if( !$obj->sameValue($pickedObject) ) //true if same color, false if different color
                             {
                                 $exit = true;
                                 $exitObject = $obj;
@@ -3546,7 +3546,7 @@ class MERGER extends UTIL
                         $exitObject = null;
                         foreach( $child_NamehashMap[ $pickedObject->name() ] as $obj )
                         {
-                            if( $obj->sameValue($pickedObject) ) //same color
+                            if( !$obj->sameValue($pickedObject) ) //same color
                             {
                                 $exit = true;
                                 $exitObject = $obj;

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1035,8 +1035,13 @@ class MERGER extends UTIL
                                 if( $this->dupAlg == 'samename' )
                                     $this->addressgroupGetValueDiff($ancestor, $object);
 
-                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
-                                if( $tmp_ancestor_DGname === "" )
+                                if( isset($ancestor->owner) )
+                                {
+                                    $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                    if( $tmp_ancestor_DGname === "" )
+                                        $tmp_ancestor_DGname = "shared";
+                                }
+                                else
                                     $tmp_ancestor_DGname = "shared";
 
                                 $text = "    - group '{$object->name()} DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
@@ -1064,9 +1069,16 @@ class MERGER extends UTIL
                                 continue;
                             }
                         }
-                        $tmp_ancestor_DGname = $ancestor->owner->owner->name();
-                        if( $tmp_ancestor_DGname === "" )
+
+                        if( isset($ancestor->owner) )
+                        {
+                            $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                            if( $tmp_ancestor_DGname === "" )
+                                $tmp_ancestor_DGname = "shared";
+                        }
+                        else
                             $tmp_ancestor_DGname = "shared";
+
 
                         if( !$this->addMissingObjects )
                         {
@@ -1410,11 +1422,35 @@ class MERGER extends UTIL
                                 $exit = TRUE;
                                 $exitObject = $obj;
                             }
+
+                            if( isset($obj->owner->parentCentralStore) )
+                            {
+                                $tmpParentStore = $obj->owner->parentCentralStore;
+                                $tmp_obj = $tmpParentStore->find( $pickedObject->name(), null, true );
+                                if( $tmp_obj !== null )
+                                {
+                                    if( (!$tmp_obj->isType_FQDN() && !$pickedObject->isType_FQDN()) && $tmp_obj->getNetworkMask() == '32' && $pickedObject->getNetworkMask() == '32' )
+                                    {
+                                        if( ($tmp_obj->getNetworkMask() == $pickedObject->getNetworkMask()) && $tmp_obj->getNetworkValue() == $pickedObject->getNetworkValue() )
+                                            $exit = FALSE;
+                                        else
+                                        {
+                                            $exit = TRUE;
+                                            $exitObject = $tmp_obj;
+                                        }
+                                    }
+                                    elseif( $tmp_obj->value() !== $pickedObject->value() )
+                                    {
+                                        $exit = TRUE;
+                                        $exitObject = $tmp_obj;
+                                    }
+                                }
+                            }
                         }
 
                         if( $exit )
                         {
-                            PH::print_stdout("   * SKIP: no creation of object in DG: '" . $tmp_DG_name . "' as object with same name '{$exitObject->name()}' and different value '{$exitObject->value()}' exist at childDG level");
+                            PH::print_stdout("   * SKIP: no creation of object in DG: '" . $tmp_DG_name . "' as object with same name '{$exitObject->name()}' and different value '{$exitObject->value()}' exist at childDG/parentDG level");
                             $this->skippedObject( $index, $pickedObject, $exitObject);
                             continue;
                         }
@@ -1582,9 +1618,14 @@ class MERGER extends UTIL
                                 if( $this->action === "merge" )
                                     $object->merge_tag_description_to($ancestor, $this->apiMode);
 
-                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
-                                if( $tmp_ancestor_DGname === "" )
-                                    $tmp_ancestor_DGname = "'shared'";
+                                if( isset($ancestor->owner) )
+                                {
+                                    $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                    if( $tmp_ancestor_DGname === "" )
+                                        $tmp_ancestor_DGname = "shared";
+                                }
+                                else
+                                    $tmp_ancestor_DGname = "shared";
 
                                 $text = "    - object '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
                                 self::deletedObject($index, $ancestor, $object);
@@ -2259,8 +2300,13 @@ class MERGER extends UTIL
 
                             if( $hashGenerator($object) == $hashGenerator($ancestor) )
                             {
-                                $tmp_ancestor_DGname = $ancestor->owner->owner->name();
-                                if( $tmp_ancestor_DGname === "" )
+                                if( isset($ancestor->owner) )
+                                {
+                                    $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                                    if( $tmp_ancestor_DGname === "" )
+                                        $tmp_ancestor_DGname = "shared";
+                                }
+                                else
                                     $tmp_ancestor_DGname = "shared";
                                 $text = "    - group '{$object->name()}' DG: '" . $object->owner->owner->name() . "' merged with its ancestor at DG: '" . $tmp_ancestor_DGname . "', deleting: " . $object->_PANC_shortName();
                                 self::deletedObject($index, $pickedObject, $object);
@@ -2287,8 +2333,13 @@ class MERGER extends UTIL
                                 continue;
                             }
                         }
-                        $tmp_ancestor_DGname = $ancestor->owner->owner->name();
-                        if( $tmp_ancestor_DGname === "" )
+                        if( isset($ancestor->owner) )
+                        {
+                            $tmp_ancestor_DGname = $ancestor->owner->owner->name();
+                            if( $tmp_ancestor_DGname === "" )
+                                $tmp_ancestor_DGname = "shared";
+                        }
+                        else
                             $tmp_ancestor_DGname = "shared";
                         PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$tmp_ancestor_DGname );
                         PH::print_stdout( "    - ancestor type: ".get_class( $ancestor ) );
@@ -2549,6 +2600,25 @@ class MERGER extends UTIL
                                 {
                                     $exit = true;
                                     $exitObject = $obj;
+                                }
+
+                                if( isset($obj->owner->parentCentralStore) )
+                                {
+                                    $tmpParentStore = $obj->owner->parentCentralStore;
+                                    $tmp_obj = $tmpParentStore->find( $pickedObject->name(), null, true );
+                                    if( $tmp_obj !== null )
+                                    {
+                                        /** @var Service $tmp_obj */
+                                        if( !$tmp_obj->dstPortMapping()->equals($pickedObject->dstPortMapping())
+                                            || !$tmp_obj->srcPortMapping()->equals($pickedObject->srcPortMapping())
+                                            || $tmp_obj->getOverride() != $pickedObject->getOverride()
+                                            || $tmp_obj->protocol() != $pickedObject->protocol()
+                                        )
+                                        {
+                                            $exit = true;
+                                            $exitObject = $tmp_obj;
+                                        }
+                                    }
                                 }
                             }
 
@@ -3103,6 +3173,7 @@ class MERGER extends UTIL
                         $exitObject = null;
                         foreach( $child_NamehashMap[ $pickedObject->name() ] as $obj )
                         {
+                            //Todo: validate if this is correct; expectation is not same color swaschkut 20230525
                             if( $obj->sameValue($pickedObject) ) //same color
                             {
                                 $exit = true;

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -69,6 +69,13 @@ class RULE_COMPARE extends UTIL
         $json_file2_name = "/tmp/" . $path2_parts['filename'] . ".json";
 
         ############################################################
+        //check if file exists
+        if( !file_exists($file1_name) )
+            derr("cannot read configuration file '{$file1_name}''", null, FALSE);
+        if( !file_exists($file2_name) )
+            derr("cannot read configuration file '{$file2_name}''", null, FALSE);
+
+        ############################################################
         $shadow_json = "shadow-json";
         $cli1 = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file1_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file1_name;
         PH::print_stdout(" - run command: '" . $cli1 . "'");


### PR DESCRIPTION
## Description
UTIL:
* type=xml-issue | extend for duplicate search on readonly device-group

BUGFIX:
* type=address-/service-merger | bugfix if two childDGs are having same object name and value - but somewhere in parentDG hierarchy below the target location DG planned for creating merged object - object with different value is available
* type=tag-merger | bugfix to exclude only these tag with different value (different color) - and merge with same value