### PR TITLE
publish version 2.1.8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=addressgroup-/servicegroup-merger - add additional output reason if groups can not be merged
 * type=userid-mgr | correct usage of objectsLocation variable
 * type=rule ruletype=nat | introduce 'actions=SNAT-set-interface:INTERFACE-NAME'
+* type=dhcp | introduce 'actions=dhcp-server-reservation-create:IP,mac'
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 BUGFIX:
 
 GENERAL:
+* develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description
 
 
 2.1.7 (20230525)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1
 * type=rule | bugfix 'filter=(dst has.recursive.from.query subquer1)' - adjust behaviour as for 'src has.recursive.from.query'
 * type=address actions=move:shared | bugfix - add validation if address object has tag, that this tag must be available at target DeviceGroup
+* type=vendor-migration vendor=ciscoasa - bugfix if staticroute destination is using wildcard netmask
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=appid-toolbox | bugfix for none declared variable php 8.1
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ UTIL:
 * type=userid-mgr | correct usage of objectsLocation variable
 * type=rule ruletype=nat | introduce 'actions=SNAT-set-interface:INTERFACE-NAME'
 * type=dhcp | introduce 'actions=dhcp-server-reservation-create:IP,mac'
+* type=service actions=name-charachter-replace:SEARCH,REPLACE - new default REPLACE value is ''
+* type=service 'filter=(name regex /ARGUMENTS/) - introduce variables same way as type=address 'filter=(name regex //)-  'possible variables to bring in as argument: $$current.name$$ / $$protocol$$ / $$destinationport$$ / $$soruceport$$ / $$timeout$$'
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=addressgroup-/servicegroup-merger - add additional output reason if groups can not be merged
 * type=userid-mgr | correct usage of objectsLocation variable
+* type=rule ruletype=nat | introduce 'actions=SNAT-set-interface:INTERFACE-NAME'
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.1.8
 UTIL:
 * type=addressgroup-/servicegroup-merger - add additional output reason if groups can not be merged
+* type=userid-mgr | correct usage of objectsLocation variable
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ BUGFIX:
 * type=rule | bugfix 'filter=(dst has.recursive.from.query subquer1)' - adjust behaviour as for 'src has.recursive.from.query'
 * type=address actions=move:shared | bugfix - add validation if address object has tag, that this tag must be available at target DeviceGroup
 * type=vendor-migration vendor=ciscoasa - bugfix if staticroute destination is using wildcard netmask
+* type=rule ruletype=nat 'actions=snat-set-interface:ethernet1$$2' | bugfix to change config also in offline config mode
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ BUGFIX:
 * type=vendor-migration vendor=ciscoasa - bugfix if staticroute destination is using wildcard netmask
 * type=rule ruletype=nat 'actions=snat-set-interface:ethernet1$$2' | bugfix to change config also in offline config mode
 * type=application 'actions=move:DGname' | bugfix if XMLnode for TargetDG is not yet available
+* type=software-remove - bugfix - skip wildfire remove - fix for PHP 8.1
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 * type=dhcp | introduce 'actions=dhcp-server-reservation-create:IP,mac'
 * type=service actions=name-charachter-replace:SEARCH,REPLACE - new default REPLACE value is ''
 * type=service 'filter=(name regex /ARGUMENTS/) - introduce variables same way as type=address 'filter=(name regex //)-  'possible variables to bring in as argument: $$current.name$$ / $$protocol$$ / $$destinationport$$ / $$soruceport$$ / $$timeout$$'
+* type=service | introduce actions=timeout-halfclose-set/timeout-timewait-set & filter=(timeout-halfclose is.set/timeout-timewait is.set / timeout-halfclose.value <>=! / timeout-timewait.value >,<,=,!
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1
+* type=rule | bugfix 'filter=(dst has.recursive.from.query subquer1)' - adjust behaviour as for 'src has.recursive.from.query'
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ BUGFIX:
 * type=address actions=move:shared | bugfix - add validation if address object has tag, that this tag must be available at target DeviceGroup
 * type=vendor-migration vendor=ciscoasa - bugfix if staticroute destination is using wildcard netmask
 * type=rule ruletype=nat 'actions=snat-set-interface:ethernet1$$2' | bugfix to change config also in offline config mode
+* type=application 'actions=move:DGname' | bugfix if XMLnode for TargetDG is not yet available
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,10 +2,12 @@ CHANGELOG
 
 2.1.8
 UTIL:
+* type=addressgroup-/servicegroup-merger - add additional output reason if groups can not be merged
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1
 * type=rule | bugfix 'filter=(dst has.recursive.from.query subquer1)' - adjust behaviour as for 'src has.recursive.from.query'
+* type=address actions=move:shared | bugfix - add validation if address object has tag, that this tag must be available at target DeviceGroup
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.7
+2.1.8
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.7 (20230525)
 UTIL:
 * type=xml-issue | extend for duplicate search on readonly device-group
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ BUGFIX:
 
 GENERAL:
 * develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description
+* general | dynamic content update to version 8721-8111
 
 
 2.1.7 (20230525)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ UTIL:
 * type=service actions=name-charachter-replace:SEARCH,REPLACE - new default REPLACE value is ''
 * type=service 'filter=(name regex /ARGUMENTS/) - introduce variables same way as type=address 'filter=(name regex //)-  'possible variables to bring in as argument: $$current.name$$ / $$protocol$$ / $$destinationport$$ / $$soruceport$$ / $$timeout$$'
 * type=service | introduce actions=timeout-halfclose-set/timeout-timewait-set & filter=(timeout-halfclose is.set/timeout-timewait is.set / timeout-halfclose.value <>=! / timeout-timewait.value >,<,=,!
+* type=address | introduce 'filter=(value netmask.blank32)'
 
 BUGFIX:
 * type=appid-toolbox | bugfix for none declared variable php 8.1

--- a/appid-toolbox/lib/common.php
+++ b/appid-toolbox/lib/common.php
@@ -639,6 +639,7 @@ class AppIDToolbox_common
         }
         elseif( $configInput['type'] == 'api' )
         {
+            $configOutput = "";
             $inputConnector = $configInput['connector'];
             if( $debugAPI )
                 $inputConnector->setShowApiCalls(TRUE);
@@ -667,5 +668,6 @@ function display_error_usage_exit($msg)
         PH::$JSON_OUT['error'] = $msg;
     else
         fwrite(STDERR, PH::boldText("\n**ERROR** ").$msg."\n\n");
-    display_usage_and_exit();
+    #APPIDTOOLBOX::display_usage_and_exit();
+    exit();
 }

--- a/appid-toolbox/lib/trait/lib_1_rule_marker.php
+++ b/appid-toolbox/lib/trait/lib_1_rule_marker.php
@@ -33,10 +33,6 @@ trait lib_1_rule_marker
         PH::print_stdout("Listing optional arguments:");
         PH::print_stdout();
 
-
-
-
-
         exit(1);
     }
 

--- a/appid-toolbox/tests/test_appid_toolbox_new.php
+++ b/appid-toolbox/tests/test_appid_toolbox_new.php
@@ -140,10 +140,10 @@ foreach( $stage_array as $item )
     if( getenv("CI") !== false )
     {
         #$cli = 'php -r "require( \'pan-diff.php file1='.$compare_folder.'/'.$item.'.xml file2='.$output_folder.'/'.$item.'.xml\' );"';
-        $cli = "php ../../utils/pan-os-php.php type=diff file1=${compare_folder}/${item}.xml file2=${output_folder}/${item}.xml";
+        $cli = "php ../../utils/pan-os-php.php type=diff file1={$compare_folder}/{$item}.xml file2={$output_folder}/{$item}.xml";
     }
     else
-        $cli = "php ../../utils/pan-os-php.php type=diff file1=${compare_folder}/${item}.xml file2=${output_folder}/${item}.xml";
+        $cli = "php ../../utils/pan-os-php.php type=diff file1={$compare_folder}/{$item}.xml file2={$output_folder}/{$item}.xml";
 
     $cli .= "  2>&1";
 

--- a/appid-toolbox/tests/test_appid_toolbox_old.php
+++ b/appid-toolbox/tests/test_appid_toolbox_old.php
@@ -133,10 +133,10 @@ foreach( $stage_array as $item )
     if( getenv("CI") !== false )
     {
         #$cli = 'php -r "require( \'pan-diff.php file1='.$compare_folder.'/'.$item.'.xml file2='.$output_folder.'/'.$item.'.xml\' );"';
-        $cli = "php ../../utils/pan-os-php.php type=diff file1=${compare_folder}/${item}.xml file2=${output_folder}/${item}.xml";
+        $cli = "php ../../utils/pan-os-php.php type=diff file1={$compare_folder}/{$item}.xml file2={$output_folder}/{$item}.xml";
     }
     else
-        $cli = "php ../../utils/pan-os-php.php type=diff file1=${compare_folder}/${item}.xml file2=${output_folder}/${item}.xml";
+        $cli = "php ../../utils/pan-os-php.php type=diff file1={$compare_folder}/{$item}.xml file2={$output_folder}/{$item}.xml";
 
     $cli .= "  2>&1";
 

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -172,7 +172,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 7;
+    private static $library_version_bugfix = 8;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1352,6 +1352,30 @@ RQuery::$defaultFilters['address']['value']['operators']['has.wrong.network'] = 
     },
     'arg' => false
 );
+RQuery::$defaultFilters['address']['value']['operators']['netmask.blank32'] = Array(
+    'Function' => function(AddressRQueryContext $context )
+    {
+        $object = $context->object;
+
+        if( $object->isGroup() )
+            return null;
+
+        if( $object->isRegion() )
+            return null;
+
+        if( !$object->isType_ipNetmask() )
+            return null;
+
+        $value = $object->getNetworkValue();
+        $netmask = $object->getNetworkMask();
+
+        if( $netmask == '32' )
+            return true;
+
+        return null;
+    },
+    'arg' => false
+);
 
 RQuery::$defaultFilters['address']['description']['operators']['regex'] = array(
     'Function' => function (AddressRQueryContext $context) {

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -1114,7 +1114,8 @@ RQuery::$defaultFilters['rule']['dst']['operators']['has.recursive.from.query'] 
         else
             $rQuery = $context->cachedSubRQuery;
 
-        foreach( $context->object->destination->all() as $member )
+        #foreach( $context->object->destination->all() as $member )
+        foreach( $context->object->destination->membersExpanded() as $member )
         {
             if( $rQuery->matchSingleObject(array('object' => $member, 'nestedQueries' => &$context->nestedQueries)) )
                 return TRUE;

--- a/lib/misc-classes/filters/filters-Service.php
+++ b/lib/misc-classes/filters/filters-Service.php
@@ -939,6 +939,55 @@ RQuery::$defaultFilters['service']['timeout.value']['operators']['>,<,=,!'] = ar
         'input' => 'input/panorama-8.0.xml'
     )
 );
+RQuery::$defaultFilters['service']['timeout-halfclose']['operators']['is.set'] = array(
+    'Function' => function (ServiceRQueryContext $context) {
+        $object = $context->object;
+        $value = $context->value;
+
+        if( !$object->isService() )
+            return null;
+
+
+        if( $object->getHalfcloseTimeout() != '' )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => FALSE
+);
+RQuery::$defaultFilters['service']['timeout-halfclose.value']['operators']['>,<,=,!'] = array(
+    'eval' => '!$object->isGroup() && $object->getHalfcloseTimeout() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+RQuery::$defaultFilters['service']['timeout-timewait']['operators']['is.set'] = array(
+    'Function' => function (ServiceRQueryContext $context) {
+        $object = $context->object;
+        $value = $context->value;
+
+        if( !$object->isService() )
+            return null;
+
+
+        if( $object->getTimewaitTimeout() != '' )
+            return TRUE;
+
+        return FALSE;
+    },
+    'arg' => FALSE
+);
+RQuery::$defaultFilters['service']['timeout-timewait.value']['operators']['>,<,=,!'] = array(
+    'eval' => '!$object->isGroup() && $object->getTimewaitTimeout() !operator! !value!',
+    'arg' => TRUE,
+    'ci' => array(
+        'fString' => '(%PROP% 1)',
+        'input' => 'input/panorama-8.0.xml'
+    )
+);
+
 
 RQuery::$defaultFilters['service']['port.count']['operators']['>,<,=,!'] = array(
     'Function' => function (ServiceRQueryContext $context) {

--- a/lib/misc-classes/filters/filters-Service.php
+++ b/lib/misc-classes/filters/filters-Service.php
@@ -221,6 +221,32 @@ RQuery::$defaultFilters['service']['name']['operators']['regex'] = array(
             $value = $context->nestedQueries[$value];
         }
 
+        if( strpos($value, '$$current.name$$') !== FALSE )
+        {
+            $replace = $object->name();
+            $value = str_replace('$$current.name$$', $replace, $value);
+        }
+        if( strpos($value, '$$protocol$$') !== FALSE )
+        {
+            $replace = $object->protocol();
+            $value = str_replace('$$protocol$$', $replace, $value);
+        }
+        if( strpos($value, '$$destinationport$$') !== FALSE )
+        {
+            $replace = $object->getDestPort();
+            $value = str_replace('$$destinationport$$', $replace, $value);
+        }
+        if( strpos($value, '$$sourceport$$') !== FALSE )
+        {
+            $replace = $object->getSourcePort();
+            $value = str_replace('$$sourceport$$', $replace, $value);
+        }
+        if( strpos($value, '$$timeout$$') !== FALSE )
+        {
+            $replace = $object->getTimeout();
+            $value = str_replace('$$timeout$$', $replace, $value);
+        }
+
         $matching = preg_match($value, $object->name());
         if( $matching === FALSE )
             derr("regular expression error on '{$value}'");
@@ -229,6 +255,7 @@ RQuery::$defaultFilters['service']['name']['operators']['regex'] = array(
         return FALSE;
     },
     'arg' => TRUE,
+    'help' => 'possible variables to bring in as argument: $$current.name$$ / $$protocol$$ / $$destinationport$$ / $$soruceport$$ / $$timeout$$',
     'ci' => array(
         'fString' => '(%PROP% /tcp/)',
         'input' => 'input/panorama-8.0.xml'

--- a/lib/network-classes/DHCP.php
+++ b/lib/network-classes/DHCP.php
@@ -71,10 +71,14 @@ class DHCP
 
                     $tmp_IP = DH::findAttribute('name', $entry);
                     $tmp_mac_xml = DH::findFirstElement("mac", $entry);
-                    $tmp_mac = $tmp_mac_xml->textContent;
+                    if( $tmp_mac_xml !== False )
+                    {
+                        $tmp_mac = $tmp_mac_xml->textContent;
 
-                    $this->server_leases[] = array( 'ip' => $tmp_IP, 'mac' => $tmp_mac );
-                    #PH::print_stdout("   * "."IP: ".$tmp_IP." | mac: ".$tmp_mac);
+                        $this->server_leases[] = array( 'ip' => $tmp_IP, 'mac' => $tmp_mac );
+                        #PH::print_stdout("   * "."IP: ".$tmp_IP." | mac: ".$tmp_mac);
+                    }
+
                 }
             }
         }

--- a/lib/network-classes/DHCP.php
+++ b/lib/network-classes/DHCP.php
@@ -26,7 +26,7 @@ class DHCP
 
     /** @var DHCPStore */
     public $owner;
-
+    public $server_leases = array();
 
     /**
      * @param $name string
@@ -57,6 +57,27 @@ class DHCP
             mwarning( "interface with name: ".$this->name." can not be found for DHCP: ".$this->name." | ".$this->owner->owner->_PANC_shortName(), null, FALSE );
 
         ///todo: update interface list - to correctly show all interfaces
+
+        $tmp_server = DH::findFirstElement("server", $xml);
+        if( $tmp_server !== false )
+        {
+            $tmp_reserved = DH::findFirstElement("reserved", $tmp_server);
+            if( $tmp_reserved !== false )
+            {
+                foreach( $tmp_reserved->childNodes as $entry )
+                {
+                    if( $entry->nodeType != XML_ELEMENT_NODE )
+                        continue;
+
+                    $tmp_IP = DH::findAttribute('name', $entry);
+                    $tmp_mac_xml = DH::findFirstElement("mac", $entry);
+                    $tmp_mac = $tmp_mac_xml->textContent;
+
+                    $this->server_leases[] = array( 'ip' => $tmp_IP, 'mac' => $tmp_mac );
+                    #PH::print_stdout("   * "."IP: ".$tmp_IP." | mac: ".$tmp_mac);
+                }
+            }
+        }
     }
 
     /**

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -569,8 +569,6 @@ class Address
             else
                 return 32;
         }
-
-
         else
             return intval($explode[1]);
     }

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -772,6 +772,9 @@ class AddressGroup
 
 
         $retString .= $indent . "Diff for between " . $this->toString() . " vs " . $otherObject->toString() . "\n";
+        $retString .= $indent . "  ' - ' means missing member \n";
+        $retString .= $indent . "  ' + ' means additional member \n";
+        $retString .= $indent . "       in ".$this->_PANC_shortName()."\n";
 
         $diff = $this->getValueDiff($otherObject);
 

--- a/lib/object-classes/AppStore.php
+++ b/lib/object-classes/AppStore.php
@@ -863,16 +863,23 @@ class AppStore extends ObjStore
         if( $Obj->isApplicationCustom() )
         {
             $this->apps_custom[$objectName] = $Obj;
+            if( $this->appCustomRoot === null )
+                $this->appCustomRoot = DH::findFirstElementOrCreate("application", $this->owner->xmlroot);
             $this->appCustomRoot->appendChild($Obj->xmlroot);
         }
         elseif( $Obj->isApplicationFilter() )
         {
             $this->app_filters[$objectName] = $Obj;
+            if( $this->appFilterRoot === null )
+                $this->appFilterRoot = DH::findFirstElementOrCreate("application-filter", $this->owner->xmlroot);
             $this->appFilterRoot->appendChild($Obj->xmlroot);
         }
         elseif( $Obj->isApplicationGroup() )
         {
             $this->app_groups[$objectName] = $Obj;
+            if( $this->appGroupRoot === null )
+                $this->appGroupRoot = DH::findFirstElementOrCreate("application-group", $this->owner->xmlroot);
+
             $this->appGroupRoot->appendChild($Obj->xmlroot);
         }
         else

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -293,6 +293,9 @@ class Service
         if( $newTimeout == 3600 )
             return FALSE;
 
+        if( $newTimeout > 604800 )
+            return FALSE;
+
         $this->_timeout = $newTimeout;
         $tmp = DH::findFirstElementOrCreate('override', $this->tcpOrUdpRoot);
         $tmpno = DH::findFirstElement('no', $tmp);
@@ -336,6 +339,9 @@ class Service
         if( $newHalfCloseTimeout == 3600 )
             return FALSE;
 
+        if( $newHalfCloseTimeout > 604800 )
+            return FALSE;
+
         $this->_halfclose_timeout = $newHalfCloseTimeout;
         $tmp = DH::findFirstElementOrCreate('override', $this->tcpOrUdpRoot);
         $tmpno = DH::findFirstElement('no', $tmp);
@@ -377,6 +383,9 @@ class Service
             return FALSE;
 
         if( $newTimeWaitTimeout == 3600 )
+            return FALSE;
+
+        if( $newTimeWaitTimeout > 600 )
             return FALSE;
 
         $this->_timewait_timeout = $newTimeWaitTimeout;

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -342,7 +342,7 @@ class Service
         if( $tmpno !== false )
             $tmp->removeChild( $tmpno );
         $tmp = DH::findFirstElementOrCreate('yes', $tmp);
-        $tmp = DH::findFirstElementOrCreate('halfclose-', $tmp, $this->_halfclose_timeout);
+        $tmp = DH::findFirstElementOrCreate('halfclose-timeout', $tmp, $this->_halfclose_timeout);
         DH::setDomNodeText($tmp, $newHalfCloseTimeout);
 
         return TRUE;
@@ -385,7 +385,7 @@ class Service
         if( $tmpno !== false )
             $tmp->removeChild( $tmpno );
         $tmp = DH::findFirstElementOrCreate('yes', $tmp);
-        $tmp = DH::findFirstElementOrCreate('timewait-', $tmp, $this->_timewait_timeout);
+        $tmp = DH::findFirstElementOrCreate('timewait-timeout', $tmp, $this->_timewait_timeout);
         DH::setDomNodeText($tmp, $newTimeWaitTimeout);
 
         return TRUE;

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -189,9 +189,8 @@ class Service
     public function API_setDestPort($newPorts)
     {
         $ret = $this->setDestPort($newPorts);
-        $connector = findConnectorOrDie($this);
-
-        $this->API_sync();
+        if( $ret )
+            $this->API_sync();
 
         return $ret;
     }
@@ -231,9 +230,8 @@ class Service
     public function API_setSourcePort($newPorts)
     {
         $ret = $this->setSourcePort($newPorts);
-        $connector = findConnectorOrDie($this);
-
-        $this->API_sync();
+        if( $ret )
+            $this->API_sync();
 
         return $ret;
     }
@@ -298,8 +296,6 @@ class Service
             }
             if( $newTimeout == 3600 )
             {
-                //default value - clear existing value
-                #return FALSE;
                 $clear = true;
                 $this->_timeout = "";
             }
@@ -321,8 +317,6 @@ class Service
             }
             if( $newTimeout == 120 )
             {
-                //default value - clear existing value
-                #return FALSE;
                 $clear = true;
                 $this->_halfclose_timeout = "";
             }
@@ -343,8 +337,6 @@ class Service
             }
             if( $newTimeout == 15 )
             {
-                //default value - clear existing value
-                #return FALSE;
                 $clear = true;
                 $this->_timewait_timeout = "";
             }
@@ -399,10 +391,7 @@ class Service
     {
         $ret = $this->setTimeout($newTimeout);
         if( $ret )
-        {
-            $connector = findConnectorOrDie($this);
             $this->API_sync();
-        }
 
         return $ret;
     }
@@ -426,10 +415,7 @@ class Service
     {
         $ret = $this->setHalfCloseTimeout($newHalfCloseTimeout);
         if( $ret )
-        {
-            $connector = findConnectorOrDie($this);
             $this->API_sync();
-        }
 
         return $ret;
     }
@@ -453,10 +439,7 @@ class Service
     {
         $ret = $this->setTimeWaitTimeout($newTimeWaitTimeout);
         if( $ret )
-        {
-            $connector = findConnectorOrDie($this);
             $this->API_sync();
-        }
 
         return $ret;
     }
@@ -495,10 +478,7 @@ class Service
     {
         $ret = $this->removeTimeout();
         if( $ret )
-        {
-            $connector = findConnectorOrDie($this);
             $this->API_sync();
-        }
 
         return $ret;
     }

--- a/lib/object-classes/Service.php
+++ b/lib/object-classes/Service.php
@@ -322,6 +322,93 @@ class Service
     }
 
     /**
+     * @param string $newHalfCloseTimeout
+     * @return bool
+     */
+    public function setHalfCloseTimeout($newHalfCloseTimeout)
+    {
+        if( strlen($newHalfCloseTimeout) == 0 )
+            derr("invalid blank value for newHalfCloseTimeouts");
+
+        if( $newHalfCloseTimeout == $this->_halfclose_timeout )
+            return FALSE;
+
+        if( $newHalfCloseTimeout == 3600 )
+            return FALSE;
+
+        $this->_halfclose_timeout = $newHalfCloseTimeout;
+        $tmp = DH::findFirstElementOrCreate('override', $this->tcpOrUdpRoot);
+        $tmpno = DH::findFirstElement('no', $tmp);
+        if( $tmpno !== false )
+            $tmp->removeChild( $tmpno );
+        $tmp = DH::findFirstElementOrCreate('yes', $tmp);
+        $tmp = DH::findFirstElementOrCreate('halfclose-', $tmp, $this->_halfclose_timeout);
+        DH::setDomNodeText($tmp, $newHalfCloseTimeout);
+
+        return TRUE;
+    }
+
+    /**
+     * @param string $newHalfCloseTimeout
+     * @return bool
+     */
+    public function API_setHalfCloseTimeout($newHalfCloseTimeout)
+    {
+        $ret = $this->setHalfCloseTimeout($newHalfCloseTimeout);
+        if( $ret )
+        {
+            $connector = findConnectorOrDie($this);
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
+    /**
+     * @param string $newTimeWaitTimeout
+     * @return bool
+     */
+    public function setTimeWaitTimeout($newTimeWaitTimeout)
+    {
+        if( strlen($newTimeWaitTimeout) == 0 )
+            derr("invalid blank value for newTimeWaitTimeouts");
+
+        if( $newTimeWaitTimeout == $this->_timewait_timeout )
+            return FALSE;
+
+        if( $newTimeWaitTimeout == 3600 )
+            return FALSE;
+
+        $this->_timewait_timeout = $newTimeWaitTimeout;
+        $tmp = DH::findFirstElementOrCreate('override', $this->tcpOrUdpRoot);
+        $tmpno = DH::findFirstElement('no', $tmp);
+        if( $tmpno !== false )
+            $tmp->removeChild( $tmpno );
+        $tmp = DH::findFirstElementOrCreate('yes', $tmp);
+        $tmp = DH::findFirstElementOrCreate('timewait-', $tmp, $this->_timewait_timeout);
+        DH::setDomNodeText($tmp, $newTimeWaitTimeout);
+
+        return TRUE;
+    }
+
+    /**
+     * @param string $newTimeWaitTimeout
+     * @return bool
+     */
+    public function API_setTimeWaitTimeout($newTimeWaitTimeout)
+    {
+        $ret = $this->setTimeWaitTimeout($newTimeWaitTimeout);
+        if( $ret )
+        {
+            $connector = findConnectorOrDie($this);
+            $this->API_sync();
+        }
+
+        return $ret;
+    }
+
+
+    /**
      * @param string $newPorts
      * @return bool
      */

--- a/lib/object-classes/ServiceGroup.php
+++ b/lib/object-classes/ServiceGroup.php
@@ -538,10 +538,12 @@ class ServiceGroup
 
         $indent = str_pad(' ', $indent);
 
-        if( !$toString )
-            PH::print_stdout(  $indent . "Diff between " . $this->_PANC_shortName() . " vs " . $otherObject->_PANC_shortName() );
-        else
-            $retString .= $indent . "Diff for between " . $this->_PANC_shortName() . " vs " . $otherObject->_PANC_shortName() ."\n" ;
+
+        $retString .= $indent . "Diff for between " . $this->_PANC_shortName() . " vs " . $otherObject->_PANC_shortName() ."\n" ;
+        $retString .= $indent . "  ' - ' means missing member \n";
+        $retString .= $indent . "  ' + ' means additional member \n";
+        $retString .= $indent . "       in ".$this->_PANC_shortName()."\n";
+
 
         $lO = array();
         $oO = array();
@@ -583,6 +585,8 @@ class ServiceGroup
 
         if( $toString )
             return $retString;
+
+        PH::print_stdout( $retString );
     }
 
 

--- a/lib/rule-classes/NatRule.php
+++ b/lib/rule-classes/NatRule.php
@@ -834,6 +834,7 @@ class NatRule extends Rule
 
 
         //rewrite SNAT needed
+        $this->rewriteSNAT_XML();
 
         return TRUE;
     }

--- a/lib/rule-classes/NatRule.php
+++ b/lib/rule-classes/NatRule.php
@@ -838,6 +838,44 @@ class NatRule extends Rule
         return TRUE;
     }
 
+    public function API_setSNATInterface($newSNATInterface)
+    {
+        $ret = $this->setSNATInterface($newSNATInterface);
+        if( $ret )
+        {
+            $connector = findConnectorOrDie($this);
+            $sourceNatType = $this->SourceNat_Type();
+
+            /*
+             * return $this->snattype == 'none';
+            return $this->snattype == 'dynamic-ip';
+            return $this->snattype == 'dynamic-ip-and-port';
+            return $this->snattype == 'static-ip';
+             */
+            if( $sourceNatType == "none" )
+            {
+                return FALSE;
+            }
+            elseif( $sourceNatType == "dynamic-ip" )
+            {
+                return FALSE;
+            }
+            elseif( $sourceNatType == "dynamic-ip-and-port" )
+            {
+                //only this is possible to set
+                $xpath = $this->getXPath() . '/source-translation/'.$sourceNatType."/interface-address";
+                $connector->sendSetRequest($xpath, "<interface>".$newSNATInterface."</interface>");
+            }
+            elseif( $sourceNatType == "static-ip" )
+            {
+                return FALSE;
+            }
+        }
+
+        return $ret;
+
+    }
+
     /**
      * @param $newServiceObject Service|ServiceGroup|null use null to set ANY
      * @return bool return true if any change was made

--- a/migration/parser/CISCO/CISCOnetwork.php
+++ b/migration/parser/CISCO/CISCOnetwork.php
@@ -189,7 +189,24 @@ trait CISCOnetwork
                     if( count($tmp_array) == 2 )
                     {
                         $cidr = $tmp_array[1];
-                        $route_network = $ip_network;
+                        if( !is_int( $cidr ) )
+                        {
+                            $cidr_array = explode(".", $cidr);
+                            $tmp_hostCidr = "";
+                            foreach( $cidr_array as $key => &$entry )
+                            {
+                                $final_entry = 255 - (int)$entry;
+                                if( $key == 0 )
+                                    $tmp_hostCidr .= $final_entry;
+                                else
+                                    $tmp_hostCidr .= "." . $final_entry;
+                            }
+
+                            $cidr = cidr::netmask2cidr($tmp_hostCidr);
+                            $route_network = $tmp_array[1]."/".$cidr;
+                        }
+                        else
+                            $route_network = $ip_network;
                     }
                     else
                     {

--- a/utils/bash_autocompletion/pan-os-php.sh
+++ b/utils/bash_autocompletion/pan-os-php.sh
@@ -72,7 +72,7 @@ __pan-os-php_scripts()
 
 		vendor=('ciscoasa' 'netscreen' 'sonicwall' 'sophos' 'ciscoswitch' 'ciscoisr' 'fortinet' 'srx' 'cp-r80' 'cp' 'cp-beta' 'huawei' 'stonesoft' 'sidewinder')
 
-    arguments_gcp=('type=' 'in=' 'out=' 'cluster=' 'project=' 'tenantid=' 'actions=' )
+    arguments_gcp=('type=' 'in=' 'out=' 'cluster=' 'project=' 'tenantid=' 'actions=' 'region=' )
     arguments_gcp_actions=('grep' 'upload' 'download' 'onboard' 'offboard' )
 
     arguments_xpath=('type=' 'in=' 'filter-nameattribute=' 'filter-node=' 'filter-xpath=' 'display-fullxpath' 'display-nameattribute' 'display-xmlnode' 'display-xmllineno' )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1539,6 +1539,18 @@ AddressCallContext::$supportedActions[] = array(
                     }
                 }
             }
+            elseif( $object->isAddress() && !$object->isType_TMP() && !!$object->isRegion() )
+            {
+                foreach( $object->tags->getAll() as $tag )
+                {
+                    if( $targetStore->find($tag->name(), null, true ) === null )
+                    {
+                        $string = "this address object has a tag named '{$tag->name()} that does not exist in target location '{$targetLocation}'";
+                        PH::ACTIONstatus( $context, "SKIPPED", $string );
+                        return;
+                    }
+                }
+            }
 
             //validation if upper/lower level is not changed
             $tmplocalSub = $rootObject->findSubSystemByName($localLocation);

--- a/utils/common/actions-dhcp.php
+++ b/utils/common/actions-dhcp.php
@@ -28,8 +28,64 @@ DHCPCallContext::$supportedActions['display'] = Array(
         PH::print_stdout("     * ".get_class($object)." '{$object->name()}'" );
         PH::$JSON_TMP['sub']['object'][$object->name()]['name'] = $object->name();
         PH::$JSON_TMP['sub']['object'][$object->name()]['type'] = get_class($object);
+
+        PH::print_stdout("       RESERVATION:" );
+
+        foreach( $object->server_leases as $lease )
+        {
+            #PH::print_stdout("       - "."IP: ".$lease['ip']." | mac: ".$lease['mac']);
+            PH::print_stdout("       - "."".$lease['ip']." | ".$lease['mac']);
+            PH::$JSON_TMP['sub']['object'][$object->name()]['server']['reserved'][] = $lease;
+        }
     },
 
     //Todo: display routes to zone / Interface IP
 );
 
+DHCPCallContext::$supportedActions['dhcp-server-reservation-create'] = Array(
+    'name' => 'dhcp-server-reservation',
+    'MainFunction' => function ( DHCPCallContext $context )
+    {
+        $object = $context->object;
+
+        $xpath = $object->getXPath()."/server/reserved";
+
+        $tmp_ip = $context->arguments['ip'];
+        $tmp_mac = $context->arguments['mac'];
+        $tmp_mac = str_replace("$$", ":", $tmp_mac);
+
+        $tmp_array = array();
+        $tmp_array[] = array("ip"=> $tmp_ip, "mac"=> $tmp_mac);
+
+        $element = "";
+        foreach( $tmp_array as $entry)
+        {
+            $ip = $entry['ip'];
+            $mac = $entry['mac'];
+
+
+            if( $context->isAPI )
+            {
+                $element .= "<entry name='".$ip."'><mac>".$mac."</mac></entry>";
+            }
+            else
+            {
+                $tmp_server_xml = DH::findFirstElementOrCreate( 'server', $object->xmlroot );
+                $tmp_reserved_xml = DH::findFirstElementOrCreate( 'reserved', $tmp_server_xml );
+                $tmp_entry_xml = DH::findFirstElementByNameAttrOrCreate( "entry", $ip, $tmp_reserved_xml, $object->xmlroot->ownerDocument);
+                $tmp_mac_xml = DH::createElement( $tmp_entry_xml, "mac" );
+                $tmp_mac_xml->textContent = $mac;
+            }
+        }
+
+        if( $context->isAPI )
+        {
+            $con = findConnectorOrDie($object);
+            $con->sendSetRequest($xpath, $element);
+        }
+    },
+    'args' => array(
+        'ip' => array('type' => 'string', 'default' => 'false'),
+        'mac' => array('type' => 'string', 'default' => 'false'),
+    ),
+);

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -3227,6 +3227,49 @@ RuleCallContext::$supportedActions[] = array(
 );
 
 RuleCallContext::$supportedActions[] = array(
+    'name' => 'SNat-set-interface',
+    'MainFunction' => function (RuleCallContext $context) {
+        $rule = $context->object;
+        if( $rule->isDefaultSecurityRule() )
+        {
+            $string = "DefaultSecurityRule - action not supported";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+        if( !$rule->isNatRule() )
+        {
+            $string = "it's not a NAT rule" ;
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+        /** @var NatRule $rule */
+
+        if( $rule->isBiDirectional() )
+        {
+            //Todo: validation if something is needed
+            //$string = "because NAT rule is bi-directional" );
+        }
+
+        $newSNATInterface = $context->arguments['SNATInterface'];
+
+        $newSNATInterface = str_replace( "$$", "/", $newSNATInterface);
+
+        //check if FW -> is interface available?
+        if( $context->isAPI )
+        {
+            #mwarning( "SNATInterface set for API call is not yet implemented" );
+            $rule->API_setSNATInterface( $newSNATInterface );
+        }
+        else
+            $rule->setSNATInterface( $newSNATInterface );
+
+    },
+    'args' => array(
+        'SNATInterface' => array('type' => 'string', 'default' => '*nodefault*')
+    )
+);
+
+RuleCallContext::$supportedActions[] = array(
     'name' => 'name-Prepend',
     'MainFunction' => function (RuleCallContext $context) {
         $rule = $context->object;

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -1471,6 +1471,60 @@ ServiceCallContext::$supportedActions[] = array(
     'args' => array('timeoutValue' => array('type' => 'string', 'default' => '*nodefault*')),
 );
 ServiceCallContext::$supportedActions[] = array(
+    'name' => 'timeout-halfclose-set',
+    'MainFunction' => function (ServiceCallContext $context) {
+        $object = $context->object;
+        $newTimeout = $context->arguments['timeoutValue'];
+        $newTimeout = intval($newTimeout);
+
+        $class = get_class($object);
+        if( $class === 'ServiceGroup' )
+        {
+            $string = "because object is ServiceGroup";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return null;
+        }
+
+        $tmp_timeout = $object->getTimeout();
+
+        if( $tmp_timeout != $newTimeout )
+        {
+            if( $context->isAPI )
+                $object->API_setHalfCloseTimeout($newTimeout);
+            else
+                $object->setHalfCloseTimeout($newTimeout);
+        }
+    },
+    'args' => array('timeoutValue' => array('type' => 'string', 'default' => '*nodefault*')),
+);
+ServiceCallContext::$supportedActions[] = array(
+    'name' => 'timeout-timewait-set',
+    'MainFunction' => function (ServiceCallContext $context) {
+        $object = $context->object;
+        $newTimeout = $context->arguments['timeoutValue'];
+        $newTimeout = intval($newTimeout);
+
+        $class = get_class($object);
+        if( $class === 'ServiceGroup' )
+        {
+            $string = "because object is ServiceGroup";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return null;
+        }
+
+        $tmp_timeout = $object->getTimeout();
+
+        if( $tmp_timeout != $newTimeout )
+        {
+            if( $context->isAPI )
+                $object->API_setTimeWaitTimeout($newTimeout);
+            else
+                $object->setTimeWaitTimeout($newTimeout);
+        }
+    },
+    'args' => array('timeoutValue' => array('type' => 'string', 'default' => '*nodefault*')),
+);
+ServiceCallContext::$supportedActions[] = array(
     'name' => 'timeout-inherit',
     'MainFunction' => function (ServiceCallContext $context) {
         $object = $context->object;

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -1016,11 +1016,6 @@ ServiceCallContext::$supportedActions[] = array(
         {
             $newName = str_replace('$$current.name$$', $object->name(), $newName);
         }
-        if( strpos($newName, '$$value$$') !== FALSE )
-        {
-            $newName = str_replace('$$value$$', $object->value(), $newName);
-        }
-
 
         if( strpos($newName, '$$protocol$$') !== FALSE )
         {
@@ -1146,7 +1141,7 @@ ServiceCallContext::$supportedActions[] = array(
         'default' => '*nodefault*'),
         'replace' => array(
             'type' => 'string',
-            'default' => '*nodefault*')
+            'default' => '')
     ),
     'help' => ''
 );

--- a/utils/develop/create/create_dhcp_reservation.php
+++ b/utils/develop/create/create_dhcp_reservation.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * ISC License
+ *
+ * Copyright (c) 2014-2018, Palo Alto Networks Inc.
+ * Copyright (c) 2019, Palo Alto Networks Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+
+set_include_path(dirname(__FILE__) . '/../' . PATH_SEPARATOR . get_include_path());
+require_once dirname(__FILE__)."/../../../lib/pan_php_framework.php";
+require_once dirname(__FILE__)."/../../../utils/lib/UTIL.php";
+
+PH::print_stdout();
+PH::print_stdout("***********************************************");
+PH::print_stdout("*********** " . basename(__FILE__) . " UTILITY **************");
+PH::print_stdout();
+
+
+PH::print_stdout( "PAN-OS-PHP version: ".PH::frameworkVersion() );
+
+
+$supportedArguments = Array();
+$supportedArguments['in'] = Array('niceName' => 'in', 'shortHelp' => 'input file or api. ie: in=config.xml  or in=api://192.168.1.1 or in=api://0018CAEC3@panorama.company.com', 'argDesc' => '[filename]|[api://IP]|[api://serial@IP]');
+$supportedArguments['out'] = Array('niceName' => 'out', 'shortHelp' => 'output file to save config after changes. Only required when input is a file. ie: out=save-config.xml', 'argDesc' => '[filename]');
+$supportedArguments['location'] = Array('niceName' => 'location', 'shortHelp' => 'specify if you want to limit your query to a VSYS. By default location=vsys1 for PANOS. ie: location=any or location=vsys2,vsys1', 'argDesc' => '=sub1[,sub2]');
+$supportedArguments['debugapi'] = Array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
+$supportedArguments['help'] = Array('niceName' => 'help', 'shortHelp' => 'this message');
+$supportedArguments['loadpanoramapushedconfig'] = Array('niceName' => 'loadPanoramaPushedConfig', 'shortHelp' => 'load Panorama pushed config from the firewall to take in account panorama objects and rules' );
+$supportedArguments['folder'] = Array('niceName' => 'folder', 'shortHelp' => 'specify the folder where the offline files should be saved');
+
+$usageMsg = PH::boldText('USAGE: ')."php ".basename(__FILE__)." in=api:://[MGMT-IP] or in=INPUTFILE.xml out=OUTFILE.xml";
+
+$util = new UTIL( "custom", $argv, $argc, __FILE__, $supportedArguments, $usageMsg );
+$util->utilInit();
+
+##########################################
+##########################################
+
+$util->load_config();
+$util->location_filter();
+
+$pan = $util->pan;
+
+##############
+
+$sub = $pan->findVirtualSystem($util->objectsLocation[0]);
+
+$zone_array = array();
+
+
+$interface_name = "ethernet1/1";
+$dhcp_array = array();
+$dhcp_array[$interface_name] = array();
+
+$tmp['ip'] = "192.168.1.1";
+$tmp['mac'] = "01:02:03:04:05:06";
+$dhcp_array[$interface_name][] = $tmp;
+
+$tmp['ip'] = "192.168.1.20";
+$tmp['mac'] = "01:02:03:04:05:08";
+$dhcp_array[$interface_name][] = $tmp;
+
+foreach( $dhcp_array as $interface_name => $tmp_array )
+{
+    $interface = $pan->network->findInterface($interface_name);
+    if( $interface !== null )
+    {
+        $xpath = "/config/devices/entry[@name='localhost.localdomain']/network/dhcp/interface/entry[@name='".$interface->name()."']/server/reserved";
+
+        $element = "";
+        foreach( $tmp_array as $entry)
+        {
+            $ip = $entry['ip'];
+            $mac = $entry['mac'];
+
+            $element .= "<entry name='".$ip."'><mac>".$mac."</mac></entry>";
+        }
+
+        $con = $pan->connector;
+        $con->sendSetRequest($xpath, $element);
+    }
+    else
+    {
+        mwarning( "Interface: ".$interface_name." not available; dhcp lease can not be added", null, false );
+    }
+}
+
+##############################################
+
+print "\n\n\n";
+
+// save our work !!!
+if( $util->configOutput !== null )
+{
+    if( $util->configOutput != '/dev/null' )
+    {
+        $pan->save_to_file($util->configOutput);
+    }
+}
+
+
+
+print "\n\n************ END OF CREATE-INTERFACE UTILITY ************\n";
+print     "**************************************************\n";
+print "\n\n";

--- a/utils/develop/migration/f5_bigip.php
+++ b/utils/develop/migration/f5_bigip.php
@@ -303,7 +303,7 @@ foreach ($file_content as $line => $names_line) {
 
             if( $tmp_servicegroup->isGroup() )
             {
-                mwarning("PANOS does not support description on ServiceGroup!!!");
+                mwarning("PANOS does not support description on ServiceGroup!!!", null, False);
             }
             else
                 $tmp_servicegroup->setDescription( $description );
@@ -440,6 +440,7 @@ foreach ($file_content as $line => $names_line) {
         continue(1);
     }
 
+    $readRules=false;
     if ($isPolicy){
         if ($names_line_original=="}"){
             $isPolicy=false;

--- a/utils/develop/object-merger.php
+++ b/utils/develop/object-merger.php
@@ -1,0 +1,135 @@
+<?php
+
+// load PAN-OS-PHP library
+require_once("lib/pan_php_framework.php");
+require_once "utils/lib/UTIL.php";
+
+
+PH::print_stdout();
+PH::print_stdout("*********** START OF SCRIPT ".basename(__FILE__)." ************" );
+PH::print_stdout();
+
+
+$supportedArguments = array();
+//PREDEFINED arguments:
+$supportedArguments['in'] = array('niceName' => 'in', 'shortHelp' => 'in=filename.xml | api. ie: in=api://192.168.1.1 or in=api://0018CAEC3@panorama.company.com', 'argDesc' => '[filename]|[api://IP]|[api://serial@IP]');
+$supportedArguments['out'] = array('niceName' => 'out', 'shortHelp' => 'output file to save config after changes. Only required when input is a file. ie: out=save-config.xml', 'argDesc' => '[filename]');
+$supportedArguments['debugapi'] = array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
+$supportedArguments['help'] = array('niceName' => 'help', 'shortHelp' => 'this message');
+$supportedArguments['location'] = array('niceName' => 'Location', 'shortHelp' => 'specify if you want to limit your query to a VSYS/DG. By default location=shared for Panorama, =vsys1 for PANOS. ie: location=any or location=vsys2,vsys1', 'argDesc' => '=sub1[,sub2]');
+
+$supportedArguments['loadpanoramapushedconfig'] = array('niceName' => 'loadPanoramaPushedConfig', 'shortHelp' => 'load Panorama pushed config from the firewall to take in account panorama objects and rules');
+$supportedArguments['apitimeout'] = array('niceName' => 'apiTimeout', 'shortHelp' => 'in case API takes too long time to anwer, increase this value (default=60)');
+
+$supportedArguments['shadow-disableoutputformatting'] = array('niceName' => 'shadow-disableoutputformatting', 'shortHelp' => 'XML output in offline config is not in cleaned PHP DOMDocument structure');
+$supportedArguments['shadow-enablexmlduplicatesdeletion']= array('niceName' => 'shadow-enablexmlduplicatesdeletion', 'shortHelp' => 'if duplicate objects are available, keep only one object of the same name');
+$supportedArguments['shadow-ignoreinvalidaddressobjects']= array('niceName' => 'shadow-ignoreinvalidaddressobjects', 'shortHelp' => 'PAN-OS allow to have invalid address objects available, like object without value or type');
+$supportedArguments['shadow-apikeynohidden'] = array('niceName' => 'shadow-apikeynohidden', 'shortHelp' => 'send API-KEY in clear text via URL. this is needed for all PAN-OS version <9.0 if API mode is used. ');
+$supportedArguments['shadow-apikeynosave']= array('niceName' => 'shadow-apikeynosave', 'shortHelp' => 'do not store API key in .panconfkeystore file');
+$supportedArguments['shadow-displaycurlrequest']= array('niceName' => 'shadow-displaycurlrequest', 'shortHelp' => 'display curl information if running in API mode');
+$supportedArguments['shadow-reducexml']= array('niceName' => 'shadow-reducexml', 'shortHelp' => 'store reduced XML, without newline and remove blank characters in offline mode');
+$supportedArguments['shadow-json']= array('niceName' => 'shadow-json', 'shortHelp' => 'BETA command to display output on stdout not in text but in JSON format');
+
+//YOUR OWN arguments if needed
+$supportedArguments['argument1'] = array('niceName' => 'ARGUMENT1', 'shortHelp' => 'an argument you like to use in your script');
+$supportedArguments['optional_argument2'] = array('niceName' => 'Optional_Argument2', 'shortHelp' => 'an argument you like to define here');
+
+
+$usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " in=api:://[MGMT-IP] argument1 [optional_argument2]";
+
+
+$util = new UTIL("custom", $argv, $argc,__FILE__, $supportedArguments, $usageMsg );
+
+$util->utilInit();
+
+$util->load_config();
+$util->location_filter();
+
+
+/** @var PANConf|PanoramaConf $pan */
+$pan = $util->pan;
+
+
+/** @var VirtualSystem|DeviceGroup $sub */
+$sub = $util->sub;
+
+/** @var string $location */
+$location = $util->location;
+
+/** @var boolean $apiMode */
+$apiMode = $util->apiMode;
+
+/** @var array $args */
+$args = PH::$args;
+
+PH::print_stdout();
+PH::print_stdout( "    **********     **********" );
+PH::print_stdout();
+
+/*********************************
+ * *
+ * *  START WRITING YOUR CODE HERE
+ * *
+ * * List of available variables:
+ *
+ * * $pan : PANConf or PanoramaConf object
+ * * $location : string with location name or undefined if not provided on CLI
+ * * $sub : DeviceGroup or VirtualSystem found after looking from cli 'location' argument
+ * * $apiMode : if config file was downloaded from API directly
+ * * $args : array with all CLI arguments processed by PAN-OS-PHP
+ * *
+ */
+
+
+
+
+/*
+- merge scripts available
+        - /config/shared/service
+        - /config/shared/service-group
+        - /config/shared/address
+        - /config/shared/address-group
+        - /config/shared/tag
+
+- object reading available
+        - /config/shared/application
+        - /config/shared/application-group
+        - /config/shared/profiles
+        - /config/shared/application-filter
+        - /config/shared/schedule
+        - /config/shared/region
+        - /config/shared/profile-group
+
+
+- rule merger
+        - /config/shared/pre-rulebase
+        - /config/shared/post-rulebase
+
+
+object reading needed
+       - /config/shared/log-settings
+       - /config/shared/external-list
+       - /config/shared/authentication-object
+       - /config/shared/threats => only predefined are read
+
+
+       - /config/shared/admin-role
+       - /config/shared/pdf-summary-report
+       - /config/shared/report-group
+       - /config/shared/reports
+       - /config/shared/email-scheduler
+
+
+
+not of interest
+    - /config/shared/application-status
+    - /config/shared/content-preview
+ */
+
+
+
+$util->save_our_work();
+PH::print_stdout();
+PH::print_stdout( "************* END OF SCRIPT ".basename(__FILE__)." ************" );
+PH::print_stdout();
+

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -918,6 +918,10 @@ var subjectObject =
                     "has.wrong.network": {
                         "Function": {},
                         "arg": false
+                    },
+                    "netmask.blank32": {
+                        "Function": {},
+                        "arg": false
                     }
                 }
             }
@@ -1901,6 +1905,20 @@ var subjectObject =
     "dhcp": {
         "name": "dhcp",
         "action": {
+            "dhcp-server-reservation": {
+                "name": "dhcp-server-reservation",
+                "MainFunction": {},
+                "args": {
+                    "ip": {
+                        "type": "string",
+                        "default": "false"
+                    },
+                    "mac": {
+                        "type": "string",
+                        "default": "false"
+                    }
+                }
+            },
             "display": {
                 "name": "display",
                 "MainFunction": {}
@@ -3013,6 +3031,16 @@ var subjectObject =
                 "name": "service-Set-AppDefault",
                 "section": "service",
                 "MainFunction": {}
+            },
+            "snat-set-interface": {
+                "name": "SNat-set-interface",
+                "MainFunction": {},
+                "args": {
+                    "SNATInterface": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
             },
             "src-add": {
                 "name": "src-Add",
@@ -6177,7 +6205,7 @@ var subjectObject =
                     },
                     "replace": {
                         "type": "string",
-                        "default": "*nodefault*"
+                        "default": ""
                     }
                 },
                 "help": ""
@@ -6292,12 +6320,32 @@ var subjectObject =
                     }
                 }
             },
+            "timeout-halfclose-set": {
+                "name": "timeout-halfclose-set",
+                "MainFunction": {},
+                "args": {
+                    "timeoutValue": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
             "timeout-inherit": {
                 "name": "timeout-inherit",
                 "MainFunction": {}
             },
             "timeout-set": {
                 "name": "timeout-set",
+                "MainFunction": {},
+                "args": {
+                    "timeoutValue": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
+            "timeout-timewait-set": {
+                "name": "timeout-timewait-set",
                 "MainFunction": {},
                 "args": {
                     "timeoutValue": {
@@ -6411,6 +6459,7 @@ var subjectObject =
                     "regex": {
                         "Function": {},
                         "arg": true,
+                        "help": "possible variables to bring in as argument: $$current.name$$ \/ $$protocol$$ \/ $$destinationport$$ \/ $$soruceport$$ \/ $$timeout$$",
                         "ci": {
                             "fString": "(%PROP% \/tcp\/)",
                             "input": "input\/panorama-8.0.xml"
@@ -6704,6 +6753,46 @@ var subjectObject =
                     "is.set": {
                         "Function": {},
                         "arg": false
+                    }
+                }
+            },
+            "timeout-halfclose": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
+            "timeout-halfclose.value": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "!$object->isGroup() && $object->getHalfcloseTimeout() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "timeout-timewait": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
+            "timeout-timewait.value": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "!$object->isGroup() && $object->getTimewaitTimeout() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },

--- a/utils/lib/GCP.php
+++ b/utils/lib/GCP.php
@@ -49,7 +49,7 @@ class GCP extends UTIL
         #$supportedArguments['debugapi'] = Array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
         $this->supportedArguments['help'] = Array('niceName' => 'help', 'shortHelp' => 'this message');
         $this->supportedArguments['cluster'] = Array('niceName' => 'Cluster', 'shortHelp' => 'specify the cluster you like to connect | default: cluster=paas-fw1', 'argDesc' => '=paas-f1');
-        $this->supportedArguments['region'] = Array('niceName' => 'Region', 'shortHelp' => 'specify the region | default: region=us-central1', 'argDesc' => '=us-central1');
+        $this->supportedArguments['region'] = Array('niceName' => 'Region', 'shortHelp' => 'specify the region | default: region=us-central1 | region=europe-west3', 'argDesc' => '=us-central1');
         $this->supportedArguments['project'] = Array('niceName' => 'Project', 'shortHelp' => 'specify the project | default: project=ngfw-dev', 'argDesc' => '=ngfw-dev');
         $this->supportedArguments['tenantid'] = Array('niceName' => 'TenantID', 'shortHelp' => 'TenantID you like to use. also possible to bring in a part script will do grep', 'argDesc' => '=123456789');
         $this->supportedArguments['actions'] = Array('niceName' => 'actions', 'shortHelp' => 'specify the action the script should trigger', 'argDesc' => 'actions=grep');

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -159,7 +159,11 @@ class RULE_COMPARE extends UTIL
                 if( isset($tmp2[$key]) )
                     $rule2 = $tmp2[$key];
                 else
-                    derr("SUB: '" . $subName . "' | RULE in jsonfile2 not found: " . $key);
+                {
+                    mwarning("SUB: '" . $subName . "' | RULE in jsonfile2 not found: " . $key, null, false);
+                    continue;
+                }
+
 
 
                 $diff_src = array();

--- a/utils/lib/SOFTWAREREMOVE.php
+++ b/utils/lib/SOFTWAREREMOVE.php
@@ -20,7 +20,7 @@
 class SOFTWAREREMOVE extends UTIL
 {
     public $utilType = null;
-
+    public $actions = "display";
 
     public function utilStart()
     {
@@ -57,22 +57,20 @@ class SOFTWAREREMOVE extends UTIL
     
         if( isset(PH::$args['actions']) )
         {
-            $actions = PH::$args['actions'];
-            if( $actions !== "display" && $actions !== "delete" )
+            $this->actions = PH::$args['actions'];
+            if( $this->actions !== "display" && $this->actions !== "delete" )
             {
                 $this->display_error_usage_exit('"actions" argument only support "display" or "delete" ');
             }
         }
-        else
-            $actions = 'display';
     
     
         ########################################################################################################################
     
         $queries['software'] = '&type=op&action=complete&xpath=/operations/request/system/software/install/version';
-        $queries['wildfire'] = '&type=op&action=complete&xpath=/operations/request/wildfire/upgrade/install/file';
         $queries['anti-virus'] = '&type=op&action=complete&xpath=/operations/request/anti-virus/upgrade/install/file';
         $queries['content'] = '&type=op&action=complete&xpath=/operations/request/content/upgrade/install/file';
+        #$queries['wildfire'] = '&type=op&action=complete&xpath=/operations/request/wildfire/upgrade/install/file';
     
         ########################################################################################################################
         $connector->refreshSystemInfos();
@@ -147,8 +145,6 @@ class SOFTWAREREMOVE extends UTIL
 
     public function checkInstallation($connector, $queries)
     {
-        global $actions;
-
         foreach( $queries as $key => $query )
         {
             PH::print_stdout();
@@ -200,7 +196,8 @@ class SOFTWAREREMOVE extends UTIL
                         $version_array = explode(".", $version);
                         $mainSWversion = $version_array[0] . "." . $version_array[1] . ".0";
                     }
-                    if( $actions === 'delete' && strpos($value, $version) === FALSE && ($mainSWversion === "" || strpos($value, $mainSWversion) === FALSE) )
+
+                    if( $this->actions === 'delete' && strpos($value, $version) === FALSE && ($mainSWversion === "" || strpos($value, $mainSWversion) === FALSE) )
                     {
                         PH::enableExceptionSupport();
                         try
@@ -218,6 +215,9 @@ class SOFTWAREREMOVE extends UTIL
                             PH::print_stdout("          ***** API Error occured : " . $e->getMessage());
                         }
                     }
+                    #else
+                        #PH::print_stdout("     * do not delete, why");
+
                 }
             }
         }

--- a/utils/lib/USERIDMGR.php
+++ b/utils/lib/USERIDMGR.php
@@ -175,9 +175,9 @@ class USERIDMGR extends UTIL
 
             PH::print_stdout( " - now sending records to API ... ");
             if( $action == 'register' )
-                $this->pan->connector->userIDLogin(array_keys($records), $records, $this->location);
+                $this->pan->connector->userIDLogin(array_keys($records), $records, $this->objectsLocation);
             else
-                $this->pan->connector->userIDLogout(array_keys($records), $records, $this->location);
+                $this->pan->connector->userIDLogout(array_keys($records), $records, $this->objectsLocation);
         }
         elseif( $action == 'fakeregister' )
         {

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -917,6 +917,10 @@
                     "has.wrong.network": {
                         "Function": {},
                         "arg": false
+                    },
+                    "netmask.blank32": {
+                        "Function": {},
+                        "arg": false
                     }
                 }
             }
@@ -1900,6 +1904,20 @@
     "dhcp": {
         "name": "dhcp",
         "action": {
+            "dhcp-server-reservation": {
+                "name": "dhcp-server-reservation",
+                "MainFunction": {},
+                "args": {
+                    "ip": {
+                        "type": "string",
+                        "default": "false"
+                    },
+                    "mac": {
+                        "type": "string",
+                        "default": "false"
+                    }
+                }
+            },
             "display": {
                 "name": "display",
                 "MainFunction": {}
@@ -3012,6 +3030,16 @@
                 "name": "service-Set-AppDefault",
                 "section": "service",
                 "MainFunction": {}
+            },
+            "snat-set-interface": {
+                "name": "SNat-set-interface",
+                "MainFunction": {},
+                "args": {
+                    "SNATInterface": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
             },
             "src-add": {
                 "name": "src-Add",
@@ -6176,7 +6204,7 @@
                     },
                     "replace": {
                         "type": "string",
-                        "default": "*nodefault*"
+                        "default": ""
                     }
                 },
                 "help": ""
@@ -6291,12 +6319,32 @@
                     }
                 }
             },
+            "timeout-halfclose-set": {
+                "name": "timeout-halfclose-set",
+                "MainFunction": {},
+                "args": {
+                    "timeoutValue": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
             "timeout-inherit": {
                 "name": "timeout-inherit",
                 "MainFunction": {}
             },
             "timeout-set": {
                 "name": "timeout-set",
+                "MainFunction": {},
+                "args": {
+                    "timeoutValue": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
+            "timeout-timewait-set": {
+                "name": "timeout-timewait-set",
                 "MainFunction": {},
                 "args": {
                     "timeoutValue": {
@@ -6410,6 +6458,7 @@
                     "regex": {
                         "Function": {},
                         "arg": true,
+                        "help": "possible variables to bring in as argument: $$current.name$$ \/ $$protocol$$ \/ $$destinationport$$ \/ $$soruceport$$ \/ $$timeout$$",
                         "ci": {
                             "fString": "(%PROP% \/tcp\/)",
                             "input": "input\/panorama-8.0.xml"
@@ -6703,6 +6752,46 @@
                     "is.set": {
                         "Function": {},
                         "arg": false
+                    }
+                }
+            },
+            "timeout-halfclose": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
+            "timeout-halfclose.value": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "!$object->isGroup() && $object->getHalfcloseTimeout() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
+                    }
+                }
+            },
+            "timeout-timewait": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
+            "timeout-timewait.value": {
+                "operators": {
+                    ">,<,=,!": {
+                        "eval": "!$object->isGroup() && $object->getTimewaitTimeout() !operator! !value!",
+                        "arg": true,
+                        "ci": {
+                            "fString": "(%PROP% 1)",
+                            "input": "input\/panorama-8.0.xml"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
## Description
UTIL:
* type=addressgroup-/servicegroup-merger - add additional output reason if groups can not be merged
* type=userid-mgr | correct usage of objectsLocation variable
* type=rule ruletype=nat | introduce 'actions=SNAT-set-interface:INTERFACE-NAME'
* type=dhcp | introduce 'actions=dhcp-server-reservation-create:IP,mac'
* type=service actions=name-charachter-replace:SEARCH,REPLACE - new default REPLACE value is ''
* type=service 'filter=(name regex /ARGUMENTS/) - introduce variables same way as type=address 'filter=(name regex //)-  'possible variables to bring in as argument: $$current.name$$ / $$protocol$$ / $$destinationport$$ / $$soruceport$$ / $$timeout$$'
* type=service | introduce actions=timeout-halfclose-set/timeout-timewait-set & filter=(timeout-halfclose is.set/timeout-timewait is.set / timeout-halfclose.value <>=! / timeout-timewait.value >,<,=,!
* type=address | introduce 'filter=(value netmask.blank32)'

BUGFIX:
* type=appid-toolbox | bugfix for none declared variable php 8.1
* type=rule | bugfix 'filter=(dst has.recursive.from.query subquer1)' - adjust behaviour as for 'src has.recursive.from.query'
* type=address actions=move:shared | bugfix - add validation if address object has tag, that this tag must be available at target DeviceGroup
* type=vendor-migration vendor=ciscoasa - bugfix if staticroute destination is using wildcard netmask
* type=rule ruletype=nat 'actions=snat-set-interface:ethernet1$$2' | bugfix to change config also in offline config mode
* type=application 'actions=move:DGname' | bugfix if XMLnode for TargetDG is not yet available
* type=software-remove - bugfix - skip wildfire remove - fix for PHP 8.1

GENERAL:
* develop f5_bigip.php | improvement - PANOS do not support ServiceGroup description
* general | dynamic content update to version 8721-8111