### PR TITLE
publish version 2.1.11

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=rule | introduce new 'filter=(timestamp-rule create <>=! -30 days)' | timestamp-rule-modification
 
 BUGFIX:
+* type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column
+* type=rule actions=exporttoexcel:file.html,resolveAddresssummary | bugfix to display IP value summary for ip-wildmask objects
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=rule | introduce new 'filter=(timestamp-rule-creation <>=! -30 days)' | timestamp-rule-modification
 * type=address | introduce 'filter=(value ip4.included-in RFC1918)'
+* type=device | introduce actions=xml-extract
 
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.1.11
 UTIL:
 * type=rule | introduce new 'filter=(timestamp-rule-creation <>=! -30 days)' | timestamp-rule-modification
+* type=address | introduce 'filter=(value ip4.included-in RFC1918)'
 
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,13 +2,14 @@ CHANGELOG
 
 2.1.11
 UTIL:
-* type=rule | introduce new 'filter=(timestamp-rule create <>=! -30 days)' | timestamp-rule-modification
+* type=rule | introduce new 'filter=(timestamp-rule-creation <>=! -30 days)' | timestamp-rule-modification
 
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column
 * type=rule actions=exporttoexcel:file.html,resolveAddresssummary | bugfix to display IP value summary for ip-wildmask objects
 
 GENERAL:
+* general - update dynamic content to version: 8729-8157
 
 
 2.1.10 (20230714)
@@ -18,7 +19,7 @@ UTIL:
 BUGFIX:
 * type=custom-url-category-merger | bugfix to merge correctly objects in DG hierarchy - add reason for exportcsv=file.html
 * type=custom-url-category-merger | introduce argument allowaddingmissingobjects
-* type=playbook | adjustment to fit to PHP  version 8.1.x
+* type=playbook | adjustment to fit to PHP version 8.1.x
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.1.11
 UTIL:
+* type=rule | introduce new 'filter=(timestamp-rule create <>=! -30 days)' | timestamp-rule-modification
 
 BUGFIX:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=rule | introduce new 'filter=(timestamp-rule-creation <>=! -30 days)' | timestamp-rule-modification
 * type=address | introduce 'filter=(value ip4.included-in RFC1918)'
 * type=device | introduce actions=xml-extract
+type=bpa-generator | extend output if task_id was not correctly available in response
 
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ UTIL:
 BUGFIX:
 * type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column
 * type=rule actions=exporttoexcel:file.html,resolveAddresssummary | bugfix to display IP value summary for ip-wildmask objects
+* class Addresscommon | bugfix for type=address-merger
 
 GENERAL:
 * general - update dynamic content to version: 8729-8157

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.10
+2.1.11
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.10 (20230714)
 UTIL:
 * type=address | introduce actions=move-wildcard2network
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 
 GENERAL:
 * general - update dynamic content to version: 8729-8157
+* * class EthernetInterface - adding/removing address object instead of IP address - extend with stopping e.g. for type=address actions=name-rename if object is used on ethernet interface
 
 
 2.1.10 (20230714)

--- a/lib/device-and-system-classes/VirtualSystem.php
+++ b/lib/device-and-system-classes/VirtualSystem.php
@@ -176,6 +176,7 @@ class VirtualSystem
     public $parentDeviceGroup = null;
 
     public $version = null;
+    public $apiCache;
 
 
     public function __construct(PANConf $owner, DeviceGroup $applicableDG = null)

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -182,7 +182,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 10;
+    private static $library_version_bugfix = 11;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/RQueryContext.php
+++ b/lib/misc-classes/RQueryContext.php
@@ -14,6 +14,7 @@ class RQueryContext
     public $rQueryObject;
 
     public $nestedQueries;
+    public $cachedSubRQuery;
 
     function __construct(RQuery $r, $value = null, $nestedQueries = null)
     {

--- a/lib/misc-classes/filters/filters-Address.php
+++ b/lib/misc-classes/filters/filters-Address.php
@@ -1108,7 +1108,16 @@ RQuery::$defaultFilters['address']['value']['operators']['ip4.included-in'] = ar
         if( $object->isGroup() && ( $object->isDynamic() || $object->count() < 1 || $object->hasFQDN() ) )
             return null;
 
-        $values = explode(',', $context->value);
+        if( $context->value === "RFC1918" )
+        {
+            $values = array();
+            $values[] = "10.0.0.0/8";
+            $values[] = "172.16.0.0/12";
+            $values[] = "192.168.0.0/16";
+        }
+        else
+            $values = explode(',', $context->value);
+
         $mapping = new IP4Map();
 
         $count = 0;
@@ -1144,7 +1153,16 @@ RQuery::$defaultFilters['address']['value']['operators']['ip4.includes-full'] = 
         if( $object->isGroup() && ( $object->isDynamic() || $object->count() < 1 || $object->hasFQDN() ) )
             return null;
 
-        $values = explode(',', $context->value);
+        if( $context->value === "RFC1918" )
+        {
+            $values = array();
+            $values[] = "10.0.0.0/8";
+            $values[] = "172.16.0.0/12";
+            $values[] = "192.168.0.0/16";
+        }
+        else
+            $values = explode(',', $context->value);
+
         $mapping = new IP4Map();
 
         $count = 0;
@@ -1180,7 +1198,16 @@ RQuery::$defaultFilters['address']['value']['operators']['ip4.includes-full-or-p
         if( $object->isGroup() && ( $object->isDynamic() || $object->count() < 1 || $object->hasFQDN() ) )
             return null;
 
-        $values = explode(',', $context->value);
+        if( $context->value === "RFC1918" )
+        {
+            $values = array();
+            $values[] = "10.0.0.0/8";
+            $values[] = "172.16.0.0/12";
+            $values[] = "192.168.0.0/16";
+        }
+        else
+            $values = explode(',', $context->value);
+
         $mapping = new IP4Map();
 
         $count = 0;

--- a/lib/misc-classes/filters/filters-Rule.php
+++ b/lib/misc-classes/filters/filters-Rule.php
@@ -2976,6 +2976,50 @@ RQuery::$defaultFilters['rule']['timestamp-first-hit.fast']['operators']['>,<,=,
     'arg' => TRUE,
     'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
 );
+RQuery::$defaultFilters['rule']['timestamp-rule-creation.fast']['operators']['>,<,=,!'] = array(
+    'Function' => function (RuleRQueryContext $context) {
+        $object = $context->object;
+
+        if( !$object->isSecurityRule() && !$object->isNatRule() )
+            derr("unsupported filter : rule type " . $object->ruleNature() . " is not supported yet. " . $object->toString());
+
+        $str = $context->value;
+        if (($timestamp = strtotime($str)) === false)
+        {
+            #echo "The string ($str) is bogus"."\n";
+        }
+        else
+        {
+            #echo "$str == " . date('l dS \o\f F Y h:i:s A', $timestamp)."\n";
+        }
+
+        return $object->ruleUsageFast( $context, 'rule-creation-timestamp' );
+    },
+    'arg' => TRUE,
+    'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
+);
+RQuery::$defaultFilters['rule']['timestamp-rule-modification.fast']['operators']['>,<,=,!'] = array(
+    'Function' => function (RuleRQueryContext $context) {
+        $object = $context->object;
+
+        if( !$object->isSecurityRule() && !$object->isNatRule() )
+            derr("unsupported filter : rule type " . $object->ruleNature() . " is not supported yet. " . $object->toString());
+
+        $str = $context->value;
+        if (($timestamp = strtotime($str)) === false)
+        {
+            #echo "The string ($str) is bogus"."\n";
+        }
+        else
+        {
+            #echo "$str == " . date('l dS \o\f F Y h:i:s A', $timestamp)."\n";
+        }
+
+        return $object->ruleUsageFast( $context, 'rule-modification-timestamp' );
+    },
+    'arg' => TRUE,
+    'help' => 'returns TRUE if rule name matches the specified timestamp MM/DD/YYYY [american] / DD-MM-YYYY [european] / 21 September 2021 / -90 days',
+);
 RQuery::$defaultFilters['rule']['hit-count.fast']['operators']['>,<,=,!'] = array(
 #RQuery::$defaultFilters['rule']['rule']['operators']['last-hit-timestamp'] = array(
     'Function' => function (RuleRQueryContext $context) {

--- a/lib/network-classes/EthernetInterface.php
+++ b/lib/network-classes/EthernetInterface.php
@@ -458,6 +458,12 @@ class EthernetInterface
         if( $this->type != 'layer3' )
             derr('cannot be requested from a non Layer3 Interface');
 
+        if( is_object($ip) )
+        {
+            $ip = $ip->name();
+            derr( "adding address object to Interface not implemented yet", null, False );
+        }
+
         $ip = $this->findorCreateAddressObject( $ip );
 
 
@@ -542,6 +548,9 @@ class EthernetInterface
     {
         if( $this->type != 'layer3' )
             derr('cannot be requested from a non Layer3 Interface');
+
+        if( is_object($ip) )
+            derr( "removing address object from Interface not implemented yet", null, False );
 
         $tmp_IPv4 = array();
         foreach( $this->getLayer3IPv4Addresses() as $key => $IPv4Address )
@@ -805,9 +814,9 @@ class EthernetInterface
         {
             if( get_class( $h ) == "Address" )
             {
-                #$this->addIPv4Address( $h );
+                $this->addIPv4Address( $h );
 
-                #$this->removeIPv4Address( $old );
+                $this->removeIPv4Address( $old );
             }
 
             return;
@@ -822,8 +831,8 @@ class EthernetInterface
             $tmp_vsys = $this->owner->owner->network->findVsysInterfaceOwner($this->name());
             if( is_object($tmp_vsys) )
             {
-                $object = $tmp_vsys->addressStore->find($ip);
-                #$object = $tmp_vsys->addressStore->findOrCreate($ip);
+                ##$object = $tmp_vsys->addressStore->find($ip);
+                $object = $tmp_vsys->addressStore->findOrCreate($ip);
             }
 
             else

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -470,25 +470,51 @@ class Address
             else
                 $this->_ip4Map = IP4Map::mapFromText($this->name);
         }
-        elseif( $this->type != self::TypeIpRange && $this->type != self::TypeIpNetmask )
-        #elseif( $this->type != self::TypeIpRange && $this->type != self::TypeIpNetmask && $this->type != self::TypeIpWildcard )
+        elseif( $this->type != self::TypeIpRange && $this->type != self::TypeIpNetmask && $this->type != self::TypeIpWildcard )
         {
             $this->_ip4Map = new IP4Map();
             $this->_ip4Map->unresolved[$this->name] = $this;
         }
-        elseif( $this->type == self::TypeIpNetmask || $this->type == self::TypeIpRange )
-        #elseif( $this->type == self::TypeIpNetmask || $this->type == self::TypeIpRange || $this->type == self::TypeIpWildcard )
+        elseif( $this->type == self::TypeIpNetmask || $this->type == self::TypeIpRange || $this->type == self::TypeIpWildcard )
         {
-            /*
             if( $this->type == self::TypeIpWildcard )
             {
-                print $this->value."\n";
-                derr( "wildcard" );
+                $array = explode( "/", $this->value() );
+                $address = $array[0];
+                $wildcardmask = $array[1];
+
+                $cidr_array = explode(".", $wildcardmask);
+                $tmp_hostCidr = "";
+                foreach( $cidr_array as $key => &$entry )
+                {
+                    $final_entry = 255 - (int)$entry;
+                    if( $key == 0 )
+                        $tmp_hostCidr .= $final_entry;
+                    else
+                        $tmp_hostCidr .= ".".$final_entry;
+                }
+
+                $cidr = CIDR::netmask2cidr($tmp_hostCidr);
+                if( is_int( $cidr ) )
+                {
+                    $tmp_value = $address."/".$cidr;
+
+                    $this->_ip4Map = IP4Map::mapFromText($tmp_value);
+                    if( $this->_ip4Map->count() == 0 )
+                        $this->_ip4Map->unresolved[$this->name] = $this->value();
+                }
+                else
+                {
+                    $this->_ip4Map->unresolved[$this->name] = $this->value();
+                }
+
             }
-            */
-            $this->_ip4Map = IP4Map::mapFromText($this->value);
-            if( $this->_ip4Map->count() == 0 )
-                $this->_ip4Map->unresolved[$this->name] = $this;
+            else
+            {
+                $this->_ip4Map = IP4Map::mapFromText($this->value);
+                if( $this->_ip4Map->count() == 0 )
+                    $this->_ip4Map->unresolved[$this->name] = $this;
+            }
         }
         else
         {

--- a/lib/object-classes/trait/AddressCommon.php
+++ b/lib/object-classes/trait/AddressCommon.php
@@ -566,8 +566,12 @@ trait AddressCommon
                         continue;
                     }
 
-                    if( $this->type() !== $withObject->type() || $withObject->value() !== $tmp_addr->value() )
+                    if( $withObject->type() !== $withObject->type() || str_replace("/32", "", $withObject->value()) !== str_replace("/32", "", $tmp_addr->value() ) )
                     {
+                        if($withObject->type() !== $tmp_addr->type())
+                            print "TYPE: ".$withObject->type()."|".$tmp_addr->type()."|\n";
+                        elseif( str_replace("/32", "", $withObject->value()) !== str_replace("/32", "", $tmp_addr->value() ) )
+                            print "VALUE: ".$withObject->type()."|".$tmp_addr->type()."|\n";
                         PH::print_stdout( "- SKIP: not possible to replace due to different value: {$objectRef->toString()}" );
                         $success = false;
                         $success2 = false;

--- a/lib/rule-classes/Rule.php
+++ b/lib/rule-classes/Rule.php
@@ -1573,7 +1573,7 @@ class Rule
         /** @var @var RuleRQueryContext $context */
 
 
-        $supported_hitType = array( 'hit-count', 'last-hit-timestamp', 'first-hit-timestamp' );
+        $supported_hitType = array( 'hit-count', 'last-hit-timestamp', 'first-hit-timestamp', 'rule-creation-timestamp', 'rule-modification-timestamp');
         if( !in_array( $hitType, $supported_hitType ) )
             derr( "supported hitType: ".implode( ", ", $supported_hitType ) );
 
@@ -1762,7 +1762,9 @@ class Rule
                                 }
                             }
                         }
-                        elseif( $hitType == "last-hit-timestamp" || $hitType == "first-hit-timestamp" )
+                        elseif( $hitType == "last-hit-timestamp" || $hitType == "first-hit-timestamp"
+                            || $hitType == "rule-creation-timestamp"
+                            || $hitType == "rule-modification-timestamp" )
                         {
                             $timestamp_value = $node->textContent;
                             if( $context->value == 0 )

--- a/utils/common/DeviceCallContext.php
+++ b/utils/common/DeviceCallContext.php
@@ -26,6 +26,11 @@ class DeviceCallContext extends CallContext
     public static $commonActionFunctions = array();
     public static $supportedActions = array();
 
+    public $first;
+    public $jsonArray;
+    public $fields;
+    public $ruleContext;
+
     static public function prepareSupportedActions()
     {
         $tmpArgs = array();

--- a/utils/common/RuleCallContext.php
+++ b/utils/common/RuleCallContext.php
@@ -252,6 +252,11 @@ class RuleCallContext extends CallContext
      */
     public function ruleFieldHtmlExport($rule, $fieldName, $wrap = TRUE, $rule_hitcount_array = array())
     {
+        if( $fieldName == 'ID' )
+        {
+            //already added outside
+            return;
+        }
         if( $fieldName == 'location' )
         {
             if( $rule->owner->owner->isPanorama() || $rule->owner->owner->isFirewall() )
@@ -709,7 +714,7 @@ class RuleCallContext extends CallContext
             else
                 return self::enclose( "" );
         }
-        return self::enclose('unsupported');
+        return self::enclose("unsupported: '$fieldName'");
 
     }
 

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -3178,10 +3178,7 @@ AddressCallContext::$supportedActions['move-wildcard2network'] = array(
                 $tmp_hostCidr .= ".".$final_entry;
         }
 
-        #print $tmp_hostCidr."\n";
-
         $cidr = CIDR::netmask2cidr($tmp_hostCidr);
-
 
         if( is_int( $cidr ) )
         {
@@ -3200,7 +3197,5 @@ AddressCallContext::$supportedActions['move-wildcard2network'] = array(
             $string = "Address object of type ip-wildcard named '" . $object->name() . "' cannot moved to an ip-netmask object type. value: ".$object->value();
             PH::ACTIONlog( $context, $string );
         }
-
-
     }
 );

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -3920,3 +3920,48 @@ DeviceCallContext::$supportedActions['system-admin-session'] = array(
     ),
     'help' => "This Action is displaying the actual logged in admin sessions"
 );
+
+DeviceCallContext::$supportedActions[] = array(
+    'name' => 'xml-extract',
+    'GlobalInitFunction' => function( DeviceCallContext $context)
+    {
+        $context->newdoc = new DOMDocument;
+        $context->newdoc->preserveWhiteSpace = false;
+        $context->newdoc->formatOutput = true;
+        $context->rule = $context->newdoc->createElement('devices');
+        $context->newdoc->appendChild($context->rule);
+
+        $context->store = null;
+    },
+    'MainFunction' => function( DeviceCallContext $context)
+    {
+        $rule = $context->object;
+
+        if( $context->store === null )
+            $context->store = $rule->owner;
+
+
+        $node = $context->newdoc->importNode($rule->xmlroot, true);
+        $context->rule->appendChild($node);
+
+
+
+    },
+    'GlobalFinishFunction' => function(DeviceCallContext $context)
+    {
+        PH::$JSON_TMP['xmlroot-actions'] = $context->newdoc->saveXML();
+
+        $store = $context->store;
+
+        if( isset($store->owner->owner) && is_object($store->owner->owner) )
+            $tmp_platform = get_class( $store->owner->owner );
+        elseif( isset($store->owner) && is_object($store->owner) )
+            $tmp_platform = get_class( $store->owner );
+        else
+            $tmp_platform = get_class( $store );
+
+        PH::print_stdout( PH::$JSON_TMP, true, "xmlroot-actions" );
+        PH::$JSON_TMP = array();
+
+    },
+);

--- a/utils/develop/panorama-PA_cleanup.php
+++ b/utils/develop/panorama-PA_cleanup.php
@@ -1,0 +1,287 @@
+<?php
+
+/*
+ USAGE;
+php multiTenant_2singleTenant.php in=caixabank-running-config.xml tenant=Corporatiu out=singleTenant.xml
+ */
+
+require_once("lib/pan_php_framework.php");
+require_once ( "utils/lib/UTIL.php");
+
+PH::print_stdout();
+PH::print_stdout("***********************************************");
+PH::print_stdout("*********** " . basename(__FILE__) . " UTILITY **************");
+PH::print_stdout();
+
+PH::print_stdout( "PAN-OS-PHP version: ".PH::frameworkVersion() );
+
+$displayAttributeName = false;
+
+$supportedArguments = Array();
+$supportedArguments['in'] = Array('niceName' => 'in', 'shortHelp' => 'input file or api. ie: in=config.xml  or in=api://192.168.1.1 or in=api://0018CAEC3@panorama.company.com', 'argDesc' => '[filename]|[api://IP]|[api://serial@IP]');
+$supportedArguments['out'] = Array('niceName' => 'out', 'shortHelp' => 'output file to save config after changes. Only required when input is a file. ie: out=save-config.xml', 'argDesc' => '[filename]');
+$supportedArguments['debugapi'] = Array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
+$supportedArguments['help'] = Array('niceName' => 'help', 'shortHelp' => 'this message');
+
+$usageMsg = PH::boldText("USAGE: ")."php ".basename(__FILE__)." in=inputfile.xml ".
+    "php ".basename(__FILE__)." help          : more help messages\n";
+##############
+
+$util = new UTIL( "custom", $argv, $argc, __FILE__, $supportedArguments, $usageMsg );
+$util->utilInit();
+
+##########################################
+##########################################
+
+$util->load_config();
+#$util->location_filter();
+
+$pan = $util->pan;
+$connector = $pan->connector;
+
+
+########################################################################################################################
+
+
+
+########################################################################################################################
+
+//possible to keep DGnames
+/*
+//find all parent DGs of "Prisma Access" and keep them too
+ */
+$keepDGarray = array();
+$keepDGarray[] = "rn-dg-";
+$keepDGarray[] = "mu-dg-";
+$keepDGarray[] = "sc-dg-";
+$keepDGarray[] = "ep-dg-";
+
+$keepDGarray[] = "shared";
+$keepDGarray[] = "Prisma Access";
+$keepDGarray[] = "Mobile_User_Device_Group";
+$keepDGarray[] = "Service_Conn_Device_Group";
+$keepDGarray[] = "Remote_Network_Device_Group";
+$keepDGarray[] = "Explicit_Proxy_Device_Group";
+
+//Template-Stack
+$keepSTKarray = array();
+$keepSTKarray[] = "rn-stk-";
+$keepSTKarray[] = "mu-stk-";
+$keepSTKarray[] = "sc-stk-";
+$keepSTKarray[] = "ep-stk-";
+
+$keepSTKarray[] = "Mobile_User_Template_Stack";
+$keepSTKarray[] = "Service_Conn_Template_Stack";
+$keepSTKarray[] = "Remote_Network_Template_Stack";
+$keepSTKarray[] = "Explicit_Proxy_Template_Stack";
+/*
+Template
+
+Service_Conn_Template
+Mobile_User_Template
+rn-tpl-
+mu-tpl-
+sc-tpl-
+
+ */
+//use class
+#PH::print_stdout(PH::$JSON_TMP, false, "serials");
+PH::$JSON_TMP = array();
+
+$util->save_our_work(TRUE);
+
+$util->endOfScript();
+
+PH::print_stdout();
+PH::print_stdout("************* END OF SCRIPT " . basename(__FILE__) . " ************" );
+PH::print_stdout();
+########################################################################################################################
+function deleteTemplateDeviceGroup( &$pan, $entry )
+{
+    /** @var PanoramaConf $pan */
+
+    $array = array( 'service-connection', 'mobile-users', 'remote-networks' );
+    foreach( $array as $type )
+    {
+        $xmlNode = DH::findFirstElement( $type, $entry );
+        if( $xmlNode !== FALSE )
+        {
+            $templateStack = DH::findFirstElement( "template-stack", $xmlNode );
+            if( $templateStack !== FALSE )
+            {
+                $stack = $pan->findTemplateStack( $templateStack->textContent );
+                if( $stack !== null )
+                {
+                    PH::print_stdout( "remove TemplateStack: |".$templateStack->textContent."|\n" );
+                    $pan->removeTemplateStack( $stack );
+                }
+                else
+                {
+                    PH::print_stdout( "TemplateStack: |".$templateStack->textContent."| not found\n" );
+                }
+            }
+
+            $deviceGroup = DH::findFirstElement( "device-group", $xmlNode );
+            if( $deviceGroup !== FALSE )
+            {
+                $dg = $pan->findDeviceGroup( $deviceGroup->textContent );
+                if( $dg !== null )
+                {
+                    PH::print_stdout( "remove DeviceGroup: |".$deviceGroup->textContent."|\n" );
+                    $pan->removeDeviceGroup( $dg );
+                }
+                else
+                {
+                    PH::print_stdout( "DeviceGroup: |".$deviceGroup->textContent."| not found\n" );
+                }
+
+            }
+
+        }
+    }
+}
+function renameTemplateDeviceGroup( &$pan, $entry )
+{
+    /** @var PanoramaConf $pan */
+
+    $array = array( 'service-connection', 'mobile-users', 'remote-networks' );
+    foreach( $array as $type )
+    {
+        $xmlNode = DH::findFirstElement( $type, $entry );
+        if( $xmlNode !== FALSE )
+        {
+            $templateStack = DH::findFirstElement( "template-stack", $xmlNode );
+            if( $templateStack !== FALSE )
+            {
+                $name = $templateStack->textContent;
+                $stack = $pan->findTemplateStack( $name );
+                if( $stack !== null )
+                {
+                    if( $type == "service-connection" )
+                        $newName = "Service_Conn_Template_Stack";
+                    elseif( $type == "mobile-users" )
+                        $newName = "Mobile_User_Template_Stack";
+                    elseif( $type == "remote-networks" )
+                        $newName = "Remote_Network_Template_Stack";
+                    elseif( $type == "mobile-users-explicit-proxy" )
+                        $newName = "Explicit_Proxy_Template_Stack";
+
+                    /*
+                     *  if(  $templateStack->name() != "Mobile_User_Template_Stack" &&
+                    $templateStack->name() != "Remote_Network_Template_Stack" &&
+                    $templateStack->name() != "Service_Conn_Template_Stack" &&
+                    $templateStack->name() != "Explicit_Proxy_Template_Stack" )
+                     */
+                    if( $name !== $newName )
+                    {
+                        PH::print_stdout("rename TemplateStack: |" . $name . "| to new name: " . $newName . "\n");
+                        $stack->setName($newName);
+                        $templateStack->textContent = $newName;
+
+                        $dgMetaDataNode = DH::findXPathSingleEntryOrDie('/config/readonly/devices/entry[@name="localhost.localdomain"]/template-stack', $pan->xmlroot);
+                        $DGmetaData = DH::findFirstElementByNameAttrOrDie('entry', $name, $dgMetaDataNode);
+                        $DGmetaData->setAttribute("name", $newName);
+                    }
+                }
+                else
+                {
+                    PH::print_stdout( "TemplateStack: |".$name."| not found\n" );
+                }
+            }
+
+            $deviceGroup = DH::findFirstElement( "device-group", $xmlNode );
+            if( $deviceGroup !== FALSE )
+            {
+                $name = $deviceGroup->textContent;
+                $dg = $pan->findDeviceGroup( $name );
+                if( $dg !== null )
+                {
+                    /*
+                     * Remote_Network_Device_Group" || $DG === "Service_Conn_Device_Group
+                     */
+                    if( $type == "service-connection" )
+                        $newName = "Service_Conn_Device_Group";
+                    elseif( $type == "mobile-users" )
+                        $newName = "Mobile_User_Device_Group";
+                    elseif( $type == "remote-networks" )
+                        $newName = "Remote_Network_Device_Group";
+                    elseif( $type == "mobile-users-explicit-proxy" )
+                        $newName = "Explicit_Proxy_Device_Group";
+
+                    if( $name !== $newName )
+                    {
+                        PH::print_stdout( "rename DeviceGroup: |".$name."| to new name: ".$newName."\n" );
+                        $dg->setName( $newName );
+                        $deviceGroup->textContent = $newName;
+
+                        $dgMetaDataNode = DH::findXPathSingleEntryOrDie('/config/readonly/devices/entry[@name="localhost.localdomain"]/device-group', $pan->xmlroot);
+                        $DGmetaData = DH::findFirstElementByNameAttrOrDie('entry', $name, $dgMetaDataNode);
+                        $DGmetaData->setAttribute("name", $newName);
+                    }
+
+                }
+                else
+                {
+                    PH::print_stdout( "DeviceGroup: |".$name."| not found\n" );
+                }
+
+            }
+
+        }
+    }
+}
+
+function findMultiTenant( $util, &$availableTenants )
+{
+    global $plugins;
+    global $cloud_service_node;
+    global $cloud_service_version;
+
+    $plugin_query = "/config/devices/entry/plugins";
+
+    $panorama_dom = new DOMXPath($util->xmlDoc);
+
+    $entries = $panorama_dom->query($plugin_query);
+    $plugins = $entries->item(0);
+
+
+    if( $plugins == null )
+        derr("PLUGin section not found - stop migration!");
+
+
+    $cloud_service_node = DH::findFirstElement("cloud_services", $plugins);
+    if( $cloud_service_node === FALSE )
+    {
+        derr("cloud_service XML node not found!");
+    }
+
+
+    $cloud_service_version = DH::findAttribute("version", $cloud_service_node);
+
+
+    $multi_tenant_enable = DH::findFirstElement("multi-tenant-enable", $cloud_service_node);
+
+    if( $multi_tenant_enable === FALSE )
+        derr( "this is not a multi-tenant Plugin Panorama configuration file" );
+    else
+    {
+        #DH::DEBUGprintDOMDocument( $cloud_service_node );
+    }
+
+
+    $multi_tenant = DH::findFirstElement("multi-tenant", $cloud_service_node);
+    $tenants = DH::findFirstElement("tenants", $multi_tenant);
+
+    foreach( $tenants->childNodes as $entry )
+    {
+        /** @var DOMElement $entry */
+        if( $entry->nodeType != XML_ELEMENT_NODE )
+            continue;
+
+        $tenantName = DH::findAttribute("name", $entry);
+        $tmp_node = $entry->cloneNode(TRUE);
+        $availableTenants[$tenantName] = $tenantName;
+    }
+
+    return $tenants;
+}

--- a/utils/develop/panorama-PA_multi2singleTenant.php
+++ b/utils/develop/panorama-PA_multi2singleTenant.php
@@ -1,0 +1,326 @@
+<?php
+
+/*
+ USAGE;
+php multiTenant_2singleTenant.php in=caixabank-running-config.xml tenant=Corporatiu out=singleTenant.xml
+ */
+
+require_once("lib/pan_php_framework.php");
+require_once ( "utils/lib/UTIL.php");
+
+PH::print_stdout();
+PH::print_stdout("***********************************************");
+PH::print_stdout("*********** " . basename(__FILE__) . " UTILITY **************");
+PH::print_stdout();
+
+PH::print_stdout( "PAN-OS-PHP version: ".PH::frameworkVersion() );
+
+$displayAttributeName = false;
+
+$supportedArguments = Array();
+$supportedArguments['in'] = Array('niceName' => 'in', 'shortHelp' => 'input file or api. ie: in=config.xml  or in=api://192.168.1.1 or in=api://0018CAEC3@panorama.company.com', 'argDesc' => '[filename]|[api://IP]|[api://serial@IP]');
+$supportedArguments['out'] = Array('niceName' => 'out', 'shortHelp' => 'output file to save config after changes. Only required when input is a file. ie: out=save-config.xml', 'argDesc' => '[filename]');
+$supportedArguments['debugapi'] = Array('niceName' => 'DebugAPI', 'shortHelp' => 'prints API calls when they happen');
+$supportedArguments['help'] = Array('niceName' => 'help', 'shortHelp' => 'this message');
+$supportedArguments['tenant'] = Array('niceName' => 'tenant', 'shortHelp' => 'specify the tenant you like to keep');
+
+$usageMsg = PH::boldText("USAGE: ")."php ".basename(__FILE__)." in=inputfile.xml ".
+    "\"tenant=TENANTname\n".
+    "php ".basename(__FILE__)." help          : more help messages\n";
+##############
+
+$util = new UTIL( "custom", $argv, $argc, __FILE__, $supportedArguments, $usageMsg );
+$util->utilInit();
+
+##########################################
+##########################################
+
+$util->load_config();
+#$util->location_filter();
+
+$pan = $util->pan;
+$connector = $pan->connector;
+
+
+########################################################################################################################
+
+
+if( !isset( PH::$args['tenant'] ) )
+{
+    //missing part get all available multi tenant and display them
+    $availableTenants = array();
+    $tenants = findMultiTenant( $util, $availableTenants );
+
+    PH::print_stdout();
+    PH::print_stdout( PH::boldText( "available Tenants:" ) );
+    foreach( $availableTenants as $tenant )
+        PH::print_stdout( " - ".$tenant );
+
+    $util->display_error_usage_exit('"tenant" argument is not set: example "tenant=TENANTname');
+}
+else
+    $tenantToFind = PH::$args['tenant'];
+
+########################################################################################################################
+
+//VARIABLE declaration
+$plugins = null;
+$cloud_service_node = null;
+$cloud_service_version = null;
+
+
+//get available TENANT name
+$availableTenants = array();
+
+$tenants = findMultiTenant( $util, $availableTenants );
+
+
+foreach( $tenants->childNodes as $entry )
+{
+    /** @var DOMElement $entry */
+    if( $entry->nodeType != XML_ELEMENT_NODE )
+        continue;
+
+    $tenantName = DH::findAttribute( "name", $entry );
+    $tmp_node = $entry->cloneNode( true);
+    $availableTenants[ $tenantName ] = $tenantName;
+
+
+    if( $tenantName === $tenantToFind )
+    {
+        renameTemplateDeviceGroup( $pan, $entry );
+
+        $newdoc = new DOMDocument;
+        $element = $newdoc->createElement('cloud_services');
+        $element->setAttribute("version", $cloud_service_version);
+        $newdoc->appendChild($element);
+
+        foreach( $entry->childNodes as $childNode )
+        {
+            $node = $newdoc->importNode($childNode, true);
+            $element->appendChild($node);
+        }
+    }
+    else
+    {
+        deleteTemplateDeviceGroup( $pan, $entry );
+    }
+
+}
+
+if( !isset( $availableTenants[$tenantToFind] ) )
+{
+    print_r(array_keys($availableTenants));
+    derr( "TENANT: ".$tenantToFind." not found in this configuration file!" );
+}
+
+//Todo: remove all DG and template which are from the removed other tenantes
+// - rename DG and template to the supported once in the migration script
+
+$plugins->removeChild( $cloud_service_node );
+
+$node = $util->xmlDoc->importNode($element, true);
+$plugins->appendChild( $node );
+
+
+//use class
+#PH::print_stdout(PH::$JSON_TMP, false, "serials");
+PH::$JSON_TMP = array();
+
+$util->save_our_work(TRUE);
+
+$util->endOfScript();
+
+PH::print_stdout();
+PH::print_stdout("************* END OF SCRIPT " . basename(__FILE__) . " ************" );
+PH::print_stdout();
+########################################################################################################################
+function deleteTemplateDeviceGroup( &$pan, $entry )
+{
+    /** @var PanoramaConf $pan */
+
+    $array = array( 'service-connection', 'mobile-users', 'remote-networks' );
+    foreach( $array as $type )
+    {
+        $xmlNode = DH::findFirstElement( $type, $entry );
+        if( $xmlNode !== FALSE )
+        {
+            $templateStack = DH::findFirstElement( "template-stack", $xmlNode );
+            if( $templateStack !== FALSE )
+            {
+                $stack = $pan->findTemplateStack( $templateStack->textContent );
+                if( $stack !== null )
+                {
+                    PH::print_stdout( "remove TemplateStack: |".$templateStack->textContent."|\n" );
+                    $pan->removeTemplateStack( $stack );
+                }
+                else
+                {
+                    PH::print_stdout( "TemplateStack: |".$templateStack->textContent."| not found\n" );
+                }
+            }
+
+            $deviceGroup = DH::findFirstElement( "device-group", $xmlNode );
+            if( $deviceGroup !== FALSE )
+            {
+                $dg = $pan->findDeviceGroup( $deviceGroup->textContent );
+                if( $dg !== null )
+                {
+                    PH::print_stdout( "remove DeviceGroup: |".$deviceGroup->textContent."|\n" );
+                    $pan->removeDeviceGroup( $dg );
+                }
+                else
+                {
+                    PH::print_stdout( "DeviceGroup: |".$deviceGroup->textContent."| not found\n" );
+                }
+
+            }
+
+        }
+    }
+}
+function renameTemplateDeviceGroup( &$pan, $entry )
+{
+    /** @var PanoramaConf $pan */
+
+    $array = array( 'service-connection', 'mobile-users', 'remote-networks' );
+    foreach( $array as $type )
+    {
+        $xmlNode = DH::findFirstElement( $type, $entry );
+        if( $xmlNode !== FALSE )
+        {
+            $templateStack = DH::findFirstElement( "template-stack", $xmlNode );
+            if( $templateStack !== FALSE )
+            {
+                $name = $templateStack->textContent;
+                $stack = $pan->findTemplateStack( $name );
+                if( $stack !== null )
+                {
+                    if( $type == "service-connection" )
+                        $newName = "Service_Conn_Template_Stack";
+                    elseif( $type == "mobile-users" )
+                        $newName = "Mobile_User_Template_Stack";
+                    elseif( $type == "remote-networks" )
+                        $newName = "Remote_Network_Template_Stack";
+                    elseif( $type == "mobile-users-explicit-proxy" )
+                        $newName = "Explicit_Proxy_Template_Stack";
+
+                    /*
+                     *  if(  $templateStack->name() != "Mobile_User_Template_Stack" &&
+                    $templateStack->name() != "Remote_Network_Template_Stack" &&
+                    $templateStack->name() != "Service_Conn_Template_Stack" &&
+                    $templateStack->name() != "Explicit_Proxy_Template_Stack" )
+                     */
+                    if( $name !== $newName )
+                    {
+                        PH::print_stdout("rename TemplateStack: |" . $name . "| to new name: " . $newName . "\n");
+                        $stack->setName($newName);
+                        $templateStack->textContent = $newName;
+
+                        $dgMetaDataNode = DH::findXPathSingleEntryOrDie('/config/readonly/devices/entry[@name="localhost.localdomain"]/template-stack', $pan->xmlroot);
+                        $DGmetaData = DH::findFirstElementByNameAttrOrDie('entry', $name, $dgMetaDataNode);
+                        $DGmetaData->setAttribute("name", $newName);
+                    }
+                }
+                else
+                {
+                    PH::print_stdout( "TemplateStack: |".$name."| not found\n" );
+                }
+            }
+
+            $deviceGroup = DH::findFirstElement( "device-group", $xmlNode );
+            if( $deviceGroup !== FALSE )
+            {
+                $name = $deviceGroup->textContent;
+                $dg = $pan->findDeviceGroup( $name );
+                if( $dg !== null )
+                {
+                    /*
+                     * Remote_Network_Device_Group" || $DG === "Service_Conn_Device_Group
+                     */
+                    if( $type == "service-connection" )
+                        $newName = "Service_Conn_Device_Group";
+                    elseif( $type == "mobile-users" )
+                        $newName = "Mobile_User_Device_Group";
+                    elseif( $type == "remote-networks" )
+                        $newName = "Remote_Network_Device_Group";
+                    elseif( $type == "mobile-users-explicit-proxy" )
+                        $newName = "Explicit_Proxy_Device_Group";
+
+                    if( $name !== $newName )
+                    {
+                        PH::print_stdout( "rename DeviceGroup: |".$name."| to new name: ".$newName."\n" );
+                        $dg->setName( $newName );
+                        $deviceGroup->textContent = $newName;
+
+                        $dgMetaDataNode = DH::findXPathSingleEntryOrDie('/config/readonly/devices/entry[@name="localhost.localdomain"]/device-group', $pan->xmlroot);
+                        $DGmetaData = DH::findFirstElementByNameAttrOrDie('entry', $name, $dgMetaDataNode);
+                        $DGmetaData->setAttribute("name", $newName);
+                    }
+
+                }
+                else
+                {
+                    PH::print_stdout( "DeviceGroup: |".$name."| not found\n" );
+                }
+
+            }
+
+        }
+    }
+}
+
+function findMultiTenant( $util, &$availableTenants )
+{
+    global $plugins;
+    global $cloud_service_node;
+    global $cloud_service_version;
+
+    $plugin_query = "/config/devices/entry/plugins";
+
+    $panorama_dom = new DOMXPath($util->xmlDoc);
+
+    $entries = $panorama_dom->query($plugin_query);
+    $plugins = $entries->item(0);
+
+
+    if( $plugins == null )
+        derr("PLUGin section not found - stop migration!");
+
+
+    $cloud_service_node = DH::findFirstElement("cloud_services", $plugins);
+    if( $cloud_service_node === FALSE )
+    {
+        derr("cloud_service XML node not found!");
+    }
+
+
+    $cloud_service_version = DH::findAttribute("version", $cloud_service_node);
+
+
+    $multi_tenant_enable = DH::findFirstElement("multi-tenant-enable", $cloud_service_node);
+
+    if( $multi_tenant_enable === FALSE )
+        derr( "this is not a multi-tenant Plugin Panorama configuration file" );
+    else
+    {
+        #DH::DEBUGprintDOMDocument( $cloud_service_node );
+    }
+
+
+    $multi_tenant = DH::findFirstElement("multi-tenant", $cloud_service_node);
+    $tenants = DH::findFirstElement("tenants", $multi_tenant);
+
+    foreach( $tenants->childNodes as $entry )
+    {
+        /** @var DOMElement $entry */
+        if( $entry->nodeType != XML_ELEMENT_NODE )
+            continue;
+
+        $tenantName = DH::findAttribute("name", $entry);
+        $tmp_node = $entry->cloneNode(TRUE);
+        $availableTenants[$tenantName] = $tenantName;
+    }
+
+    return $tenants;
+}

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -202,6 +202,10 @@ var subjectObject =
                 "name": "move-range2network",
                 "MainFunction": {}
             },
+            "move-wildcard2network": {
+                "name": "move-wildcard2network",
+                "MainFunction": {}
+            },
             "name-addprefix": {
                 "name": "name-addPrefix",
                 "MainFunction": {},
@@ -4209,7 +4213,7 @@ var subjectObject =
                         "Function": {},
                         "arg": true,
                         "ci": {
-                            "fString": "(%PROP% day)",
+                            "fString": "(%PROP% \/day\/)",
                             "input": "input\/panorama-8.0.xml"
                         }
                     },
@@ -4840,6 +4844,24 @@ var subjectObject =
                 }
             },
             "timestamp-last-hit.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ -90 days"
+                    }
+                }
+            },
+            "timestamp-rule-creation.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ -90 days"
+                    }
+                }
+            },
+            "timestamp-rule-modification.fast": {
                 "operators": {
                     ">,<,=,!": {
                         "Function": {},

--- a/utils/lib/BPAGENERATOR.php
+++ b/utils/lib/BPAGENERATOR.php
@@ -171,7 +171,17 @@ class BPAGENERATOR extends UTIL
                 $reply = json_decode($response, TRUE);
                 if( $reply === null )
                     derr( "invalid JSON file provided", null, FALSE );
-                $response = $reply['task_id'];
+                if( isset( $reply['task_id'] ) )
+                {
+                    #print_r( $reply );
+                    $response = $reply['task_id'];
+                }
+                else
+                {
+                    print_r( $reply );
+                    derr( "'task_id' - not found", null, FALSE );
+                }
+
             }
         } catch(Exception $e)
         {

--- a/utils/lib/KEYMANGER.php
+++ b/utils/lib/KEYMANGER.php
@@ -29,7 +29,7 @@ class KEYMANGER extends UTIL
     Examples:
             
     - php " . basename(__FILE__) . " add=license-apikey 'apikey=[ your personal company license API key account can be found via https://support.paloaltonetworks.com -> Assets -> API key management - only super user can see this ]'
-    - php " . basename(__FILE__) . " add=bpa-apikey 'apikey=[ PAN-OS BPA can be request via: bpa@paloaltonetworks.com ]' 
+    - php " . basename(__FILE__) . " add=bpa-apikey 'apikey=[ PAN-OS BPA key can be request via: https://customersuccess.paloaltonetworks.com/api-signup/ ]' 
     - php " . basename(__FILE__) . " add=ldap-password 'apikey=[ LDAP password to interact with organisational ldap server ]'
     - php " . basename(__FILE__) . " add=maxmind-licensekey apikey=[ Maxmind license to download Maxmind geo2ip lite database. create free account: https://www.maxmind.com ]
     - php " . basename(__FILE__) . " add=tsg_id{{TSGID}} 'apikey={{CLIENT_ID}}%{{CLIENT_SECRET}}'  | character '%' must be used as separator between client_id and client_secret";

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -201,6 +201,10 @@
                 "name": "move-range2network",
                 "MainFunction": {}
             },
+            "move-wildcard2network": {
+                "name": "move-wildcard2network",
+                "MainFunction": {}
+            },
             "name-addprefix": {
                 "name": "name-addPrefix",
                 "MainFunction": {},
@@ -4208,7 +4212,7 @@
                         "Function": {},
                         "arg": true,
                         "ci": {
-                            "fString": "(%PROP% day)",
+                            "fString": "(%PROP% \/day\/)",
                             "input": "input\/panorama-8.0.xml"
                         }
                     },
@@ -4839,6 +4843,24 @@
                 }
             },
             "timestamp-last-hit.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ -90 days"
+                    }
+                }
+            },
+            "timestamp-rule-creation.fast": {
+                "operators": {
+                    ">,<,=,!": {
+                        "Function": {},
+                        "arg": true,
+                        "help": "returns TRUE if rule name matches the specified timestamp MM\/DD\/YYYY [american] \/ DD-MM-YYYY [european] \/ 21 September 2021 \/ -90 days"
+                    }
+                }
+            },
+            "timestamp-rule-modification.fast": {
                 "operators": {
                     ">,<,=,!": {
                         "Function": {},


### PR DESCRIPTION
## Description

2.1.11
UTIL:
* type=rule | introduce new 'filter=(timestamp-rule-creation <>=! -30 days)' | timestamp-rule-modification
* type=address | introduce 'filter=(value ip4.included-in RFC1918)'
* type=device | introduce actions=xml-extract
type=bpa-generator | extend output if task_id was not correctly available in response

BUGFIX:
* type=rule actions=exporttoexcel | bugfix for field 'ID' to not add additional data column
* type=rule actions=exporttoexcel:file.html,resolveAddresssummary | bugfix to display IP value summary for ip-wildmask objects
* class Addresscommon | bugfix for type=address-merger

GENERAL:
* general - update dynamic content to version: 8729-8157
* * class EthernetInterface - adding/removing address object instead of IP address - extend with stopping e.g. for type=address actions=name-rename if object is used on ethernet interface