### PR TITLE
publish version 2.1.13

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ UTIL:
 * type=service actions=exporttoexcel:file.html | correct predefined service-http/-https output
 * type=address/server actions=exporttoexcel:file.html,nestedmembers | extend with column nested members location
 * class Address - use $RuleReferenceLocation
+* type=zone | introduce 'filter=(interface is.set)'
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ UTIL:
 * type=rule 'actions=exporttoexcel:file.html,resovleservicesummary' | extend with column service_resolve_nested/_name/_value/_location
 * type=service actions=exporttoexcel:file.html | correct predefined service-http/-https output
 * type=address/server actions=exporttoexcel:file.html,nestedmembers | extend with column nested members location
+* class Address - use $RuleReferenceLocation
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="
 * type=address actions=move - bugifx/workaround - do not move region objects
 * type=addressgroup-merger | bugfix to check childancestor objects availability
+* type=addressgroup-merger | bugfix if multiple childDG has same objectgroup incl. value, but one differ; stop merging
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ UTIL:
 * type=dhcp | introduce actions=exporttoexcel:file.html
 * type=dhcp | improvement for actions=exporttoexcel
 * type=dhcp actions=display/exporttoexcel | extend with additional DHCP information
+* type=rule 'actions=exporttoexcel:file.html,resovleservicesummary' | extend with column service_resolve_nested/_name/_value/_location
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 * type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
 * type=address actions=upload-address-2cloudmanager | extend validation if object name is already available
+* type=servicegroup-merger | introduce validation extension for childDG merger
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="
@@ -152,7 +153,6 @@ UTIL:
 * type=rule-merger | argument additionalmatch - change supported argument from 'logprof' to 'logsetting'
 * type=address 'filter=(object is.region)' - extend display with custom region value information
 * type=rule-compare | introduce new utility - to compare rule SRC/DST/SRV of two files
-* type=servicegroup-merger | introduce validation extension for childDG merger
 
 BUGFIX:
 * type=address | bugfix for filter=(value string.XYZ ) if Object of type Region is hit

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
 * type=address actions=upload-address-2cloudmanager | extend validation if object name is already available
 * type=servicegroup-merger | introduce validation extension for childDG merger
+* type=rule-compare | exend with argument 'keepJSONfile1' and 'reuseJSONfile1'
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ CHANGELOG
 
 2.1.13
 UTIL:
+* type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
 
 BUGFIX:
 
@@ -11,7 +12,7 @@ GENERAL:
 2.1.12 (20230731)
 UTIL:
 * type=bpa-generator | extend response output if not valid JSON
-* type=gcp | extend for mqsql usage and bring in mysql pw in type=key-manager
+* type=gcp | extend for mysql usage and bring in mysql pw in type=key-manager
 
 BUGFIX:
 * type=XYZ | in=api://{MGMT-IP} actions=name-rename - bugfix for API usage

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="
+* type=address actions=move - bugifx/workaround - do not move region objects
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ BUGFIX:
 * type=address actions=move - bugifx/workaround - do not move region objects
 * type=addressgroup-merger | bugfix to check childancestor objects availability
 * type=addressgroup-merger | bugfix if multiple childDG has same objectgroup incl. value, but one differ; stop merging
+* class AddressGroup  | bugfix for method expand() - to correctly extract all submembers and their value for type=rule 'actions=exporttoexcel:file.html,resolveaddresssummary'
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ BUGFIX:
 * type=dhcp actions=exporttoexcel | bugfix to add correct template
 * class PH - workaround for none working API mode connector - discard setType()
 * class RULEUTIL - defaultSecurityRules not available in Fawkes Snippet
+* type=rule - actions=display/exporttoexcel:resolveaddresssummary | add new src/dst_resovled_sum - for better nested calculation
 
 GENERAL:
 * dynamic update version  8739-8206

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ UTIL:
 * type=servicegroup-merger | extend with childancestor validation
 * type=service actions=exporttoexcel:file.html | introduce additional arguments nestedmembers
 * type=XYZ actions=exporttoexcel:file.html | use single function to create spreadsheet content
+* type=dhcp | introduce actions=exporttoexcel:file.html
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 * type=rule-compare | exend with argument 'keepJSONfile1' and 'reuseJSONfile1'
 * type=rule-compare | introduce argument 'generateRuleHtmlFile'
 * type=servicegroup-merger | extend with childancestor validation
+* type=service actions=exporttoexcel:file.html | introduce additional arguments nestedmembers
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -152,6 +152,7 @@ UTIL:
 * type=rule-merger | argument additionalmatch - change supported argument from 'logprof' to 'logsetting'
 * type=address 'filter=(object is.region)' - extend display with custom region value information
 * type=rule-compare | introduce new utility - to compare rule SRC/DST/SRV of two files
+* type=servicegroup-merger | introduce validation extension for childDG merger
 
 BUGFIX:
 * type=address | bugfix for filter=(value string.XYZ ) if Object of type Region is hit

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ BUGFIX:
 * type=addressgroup-merger | bugfix to check childancestor objects availability
 * type=addressgroup-merger | bugfix if multiple childDG has same objectgroup incl. value, but one differ; stop merging
 * class AddressGroup  | bugfix for method expand() - to correctly extract all submembers and their value for type=rule 'actions=exporttoexcel:file.html,resolveaddresssummary'
+* type=address actions=exporttoexcel:file.html | bugfix to crash for tmp objects
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ UTIL:
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="
 * type=address actions=move - bugifx/workaround - do not move region objects
+* type=addressgroup-merger | bugfix to check childancestor objects availability
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ UTIL:
 * type=rule-compare | introduce argument 'generateRuleHtmlFile'
 * type=servicegroup-merger | extend with childancestor validation
 * type=service actions=exporttoexcel:file.html | introduce additional arguments nestedmembers
+* type=XYZ actions=exporttoexcel:file.html | use single function to create spreadsheet content
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ BUGFIX:
 * class AddressGroup  | bugfix for method expand() - to correctly extract all submembers and their value for type=rule 'actions=exporttoexcel:file.html,resolveaddresssummary'
 * type=address actions=exporttoexcel:file.html | bugfix to crash for tmp objects
 * type=dhcp actions=exporttoexcel | bugfix to add correct template
+* class PH - workaround for none working API mode connector - discard setType()
 
 GENERAL:
 * dynamic update version  8739-8206

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ UTIL:
 * type=dhcp actions=display/exporttoexcel | extend with additional DHCP information
 * type=rule 'actions=exporttoexcel:file.html,resovleservicesummary' | extend with column service_resolve_nested/_name/_value/_location
 * type=service actions=exporttoexcel:file.html | correct predefined service-http/-https output
+* type=address/server actions=exporttoexcel:file.html,nestedmembers | extend with column nested members location
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ UTIL:
 * type=servicegroup-merger | introduce validation extension for childDG merger
 * type=rule-compare | exend with argument 'keepJSONfile1' and 'reuseJSONfile1'
 * type=rule-compare | introduce argument 'generateRuleHtmlFile'
+* type=servicegroup-merger | extend with childancestor validation
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,7 +32,7 @@ BUGFIX:
 * type=rule - actions=display/exporttoexcel:resolveaddresssummary | add new src/dst_resovled_sum - for better nested calculation
 
 GENERAL:
-* dynamic update version  8739-8206
+* PAN-OS dynamic content update to version  8741-8213
 
 
 2.1.12 (20230731)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ UTIL:
 * type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
 
 BUGFIX:
+* class Region | bugfix - introduce method type() - to handle "type=address actions="
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ BUGFIX:
 * type=dhcp actions=exporttoexcel | bugfix to add correct template
 
 GENERAL:
+* dynamic update version  8739-8206
 
 
 2.1.12 (20230731)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ CHANGELOG
 2.1.13
 UTIL:
 * type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
+* type=address actions=upload-address-2cloudmanager | extend validation if object name is already available
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.12
+2.1.13
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.12 (20230731)
 UTIL:
 * type=bpa-generator | extend response output if not valid JSON
 * type=gcp | extend for mqsql usage and bring in mysql pw in type=key-manager

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ BUGFIX:
 * type=addressgroup-merger | bugfix if multiple childDG has same objectgroup incl. value, but one differ; stop merging
 * class AddressGroup  | bugfix for method expand() - to correctly extract all submembers and their value for type=rule 'actions=exporttoexcel:file.html,resolveaddresssummary'
 * type=address actions=exporttoexcel:file.html | bugfix to crash for tmp objects
+* type=dhcp actions=exporttoexcel | bugfix to add correct template
 
 GENERAL:
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ UTIL:
 * type=service actions=exporttoexcel:file.html | introduce additional arguments nestedmembers
 * type=XYZ actions=exporttoexcel:file.html | use single function to create spreadsheet content
 * type=dhcp | introduce actions=exporttoexcel:file.html
+* type=dhcp | improvement for actions=exporttoexcel
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ UTIL:
 * type=dhcp | improvement for actions=exporttoexcel
 * type=dhcp actions=display/exporttoexcel | extend with additional DHCP information
 * type=rule 'actions=exporttoexcel:file.html,resovleservicesummary' | extend with column service_resolve_nested/_name/_value/_location
+* type=service actions=exporttoexcel:file.html | correct predefined service-http/-https output
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ UTIL:
 * type=address actions=upload-address-2cloudmanager | extend validation if object name is already available
 * type=servicegroup-merger | introduce validation extension for childDG merger
 * type=rule-compare | exend with argument 'keepJSONfile1' and 'reuseJSONfile1'
+* type=rule-compare | introduce argument 'generateRuleHtmlFile'
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ UTIL:
 * type=XYZ actions=exporttoexcel:file.html | use single function to create spreadsheet content
 * type=dhcp | introduce actions=exporttoexcel:file.html
 * type=dhcp | improvement for actions=exporttoexcel
+* type=dhcp actions=display/exporttoexcel | extend with additional DHCP information
 
 BUGFIX:
 * class Region | bugfix - introduce method type() - to handle "type=address actions="

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ BUGFIX:
 * type=address actions=exporttoexcel:file.html | bugfix to crash for tmp objects
 * type=dhcp actions=exporttoexcel | bugfix to add correct template
 * class PH - workaround for none working API mode connector - discard setType()
+* class RULEUTIL - defaultSecurityRules not available in Fawkes Snippet
 
 GENERAL:
 * dynamic update version  8739-8206

--- a/lib/container-classes/AddressRuleContainer.php
+++ b/lib/container-classes/AddressRuleContainer.php
@@ -623,7 +623,7 @@ class AddressRuleContainer extends ObjRuleContainer
             elseif( $member->isAddress() )
             {
                 /** @var Address $member */
-                $localMap = $member->getIP4Mapping();
+                $localMap = $member->getIP4Mapping( $RuleReferenceLocation );
                 $mapObject->addMap($localMap, TRUE);
             }
             elseif( $member->isGroup() )
@@ -640,7 +640,7 @@ class AddressRuleContainer extends ObjRuleContainer
             elseif( $member->isRegion() )
             {
                 /** @var Region $member */
-                $localMap = $member->getIP4Mapping();
+                $localMap = $member->getIP4Mapping( $RuleReferenceLocation );
                 $mapObject->addMap($localMap, TRUE);
             }
             else

--- a/lib/container-classes/AddressRuleContainer.php
+++ b/lib/container-classes/AddressRuleContainer.php
@@ -189,7 +189,7 @@ class AddressRuleContainer extends ObjRuleContainer
     }
 
 
-    public function API_sync()
+    public function API_sync( $new = false )
     {
         $con = findConnectorOrDie($this);
 
@@ -210,7 +210,14 @@ class AddressRuleContainer extends ObjRuleContainer
             }
         }
         elseif( $con->isSaseAPI() )
-            $con->sendPUTRequest($this);
+        {
+            if( $new )
+                $con->sendCreateRequest($this);
+            else
+                $con->sendPUTRequest($this);
+        }
+
+
     }
 
     public function setAny()

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -471,7 +471,8 @@ class PH
                         $host = $fileExplode[0];
                     }
                     $connector = PanAPIConnector::findOrCreateConnectorFromHost($host);
-                    $connector->setType($connector->info_deviceType);
+                    #swaschkut: not working 20230807
+                    #$connector->setType($connector->info_deviceType);
                 }
                 else
                 {

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -182,7 +182,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 12;
+    private static $library_version_bugfix = 13;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/lib/misc-classes/PanSaseAPIConnector.php
+++ b/lib/misc-classes/PanSaseAPIConnector.php
@@ -640,6 +640,7 @@ class PanSaseAPIConnector
 
                         $tmp_addressgroup->setSaseID( $object['id'] );
                     }
+                    //elseif( isset($object['dynamic']) )
                 }
             }
             elseif( $type === "services" )

--- a/lib/misc-classes/PanSaseAPIConnector.php
+++ b/lib/misc-classes/PanSaseAPIConnector.php
@@ -904,6 +904,26 @@ class PanSaseAPIConnector
 
             return $bodyArray;
         }
+        if( get_class( $object ) == "AddressGroup" )
+        {
+            //Sase-API
+
+            $bodyArray['description'] = $object->description();
+            $bodyArray['name'] = $object->name();
+            $bodyArray['folder'] = $object->owner->owner->name();
+            $memberArray = $object->members();
+            if( !$object->isDynamic() )
+            {
+                $bodyArray['static'] = array();
+                foreach($memberArray as $member)
+                    $bodyArray['static'][] = $member->name();
+            }
+            else
+                $bodyArray['dynamic']['filter'] = $object->filter;
+
+
+            return $bodyArray;
+        }
         elseif( get_class( $object ) == "Service" )
         {
             //Sase-API

--- a/lib/misc-classes/PanSaseAPIConnector.php
+++ b/lib/misc-classes/PanSaseAPIConnector.php
@@ -41,6 +41,8 @@ class PanSaseAPIConnector
 
     public $url_token = "https://auth.apps.paloaltonetworks.com/oauth2/access_token";
     public $url_api = "https://api.sase.paloaltonetworks.com";
+    #public $url_api = "https://api.stratacloud.paloaltonetworks.com"; //identical to api.sase.paloaltonetworks.com but introduced on 20230801
+
 
     static public $folderArray = array(
         "All",

--- a/lib/misc-classes/filters/filters-Zone.php
+++ b/lib/misc-classes/filters/filters-Zone.php
@@ -471,4 +471,19 @@ RQuery::$defaultFilters['zone']['userid']['operators']['is.enabled'] = array(
         'input' => 'input/panorama-8.0.xml'
     )
 );
+
+RQuery::$defaultFilters['zone']['interface']['operators']['is.set'] = array(
+    'Function' => function (ZoneRQueryContext $context) {
+        $object = $context->object;
+
+        $interfaces = $object->attachedInterfaces->getAll();
+        if( count($interfaces) > 0)
+            return TRUE;
+        else
+            return FALSE;
+
+        return null;
+    },
+    'arg' => FALSE
+);
 // </editor-fold>

--- a/lib/misc-classes/trait/XmlConvertible.php
+++ b/lib/misc-classes/trait/XmlConvertible.php
@@ -54,7 +54,7 @@ trait XmlConvertible
         return DH::domlist_to_xml($this->xmlroot->childNodes, -1, FALSE);
     }
 
-    public function API_sync()
+    public function API_sync( $new = false)
     {
         $xpath = DH::elementToPanXPath($this->xmlroot);
         $con = findConnectorOrDie($this);
@@ -62,7 +62,13 @@ trait XmlConvertible
         if( $con->isAPI() )
             $con->sendEditRequest($xpath, $this->getXmlText_inline());
         elseif( $con->isSaseAPI() )
-            $con->sendPUTRequest($this);
+        {
+            if( $new )
+                $con->sendCreateRequest($this);
+            else
+                $con->sendPUTRequest($this);
+        }
+
     }
 
 

--- a/lib/network-classes/Certificate.php
+++ b/lib/network-classes/Certificate.php
@@ -266,14 +266,13 @@ class Certificate
             $c = findConnectorOrDie($this);
             $path = $this->getXPath();
 
+            $this->setName($newname);
             $c->sendRenameRequest($path, $newname);
         }
         else
         {
             mwarning('this is a temporary object, cannot be renamed from API');
         }
-
-        $this->setName($newname);
     }
 
     public function hasPublicKey()

--- a/lib/network-classes/DHCP.php
+++ b/lib/network-classes/DHCP.php
@@ -81,7 +81,42 @@ class DHCP
 
                 }
             }
+
+            #DH::DEBUGprintDOMDocument($tmp_server);
+
+                /*
+              <option>
+               <lease>
+                <unlimited/>
+               </lease>
+              </option>
+              <ip-pool>
+               <member>192.168.10.127/28</member>
+              </ip-pool>
+              <mode>auto</mode>
+             */
+
+
         }
+        $tmp_relay = DH::findFirstElement("relay", $xml);
+        if( $tmp_relay !== false )
+        {
+            #DH::DEBUGprintDOMDocument($tmp_relay);
+            /*
+            <relay>
+                <ip>
+                    <server>
+                        <member>1.2.3.4</member>
+                    </server>
+                    <enabled>yes</enabled>
+                </ip>
+                <ipv6>
+                    <enabled>no</enabled>
+                </ipv6>
+            </relay>
+             */
+        }
+
     }
 
     /**

--- a/lib/network-classes/Zone.php
+++ b/lib/network-classes/Zone.php
@@ -259,14 +259,13 @@ class Zone
             $c = findConnectorOrDie($this);
             $path = $this->getXPath();
 
+            $this->setName($newname);
             $c->sendRenameRequest($path, $newname);
         }
         else
         {
             mwarning('this is a temporary object, cannot be renamed from API');
         }
-
-        $this->setName($newname);
     }
 
     /**

--- a/lib/object-classes/Address.php
+++ b/lib/object-classes/Address.php
@@ -452,34 +452,39 @@ class Address
      * Return an array['start']= startip and ['end']= endip
      * @return IP4Map
      */
-    public function getIP4Mapping()
+    public function getIP4Mapping( $RuleReferenceLocation = null )
     {
-        if( isset($this->_ip4Map) )
+        if( $RuleReferenceLocation !== null )
+            $object = $RuleReferenceLocation->addressStore->find($this->name());
+        else
+            $object = $this;
+            
+        if( isset($object->_ip4Map) )
         {
-            return $this->_ip4Map;
+            return $object->_ip4Map;
         }
 
-        if( $this->isTmpAddr() )
+        if( $object->isTmpAddr() )
         {
-            if( !$this->nameIsValidRuleIPEntry() )
+            if( !$object->nameIsValidRuleIPEntry() )
             {
                 // if this object is temporary/unsupported, we send an empty mapping
-                $this->_ip4Map = new IP4Map();
-                $this->_ip4Map->unresolved[$this->name] = $this;
+                $object->_ip4Map = new IP4Map();
+                $object->_ip4Map->unresolved[$object->name] = $object;
             }
             else
-                $this->_ip4Map = IP4Map::mapFromText($this->name);
+                $object->_ip4Map = IP4Map::mapFromText($object->name);
         }
-        elseif( $this->type != self::TypeIpRange && $this->type != self::TypeIpNetmask && $this->type != self::TypeIpWildcard )
+        elseif( $object->type != self::TypeIpRange && $object->type != self::TypeIpNetmask && $object->type != self::TypeIpWildcard )
         {
-            $this->_ip4Map = new IP4Map();
-            $this->_ip4Map->unresolved[$this->name] = $this;
+            $object->_ip4Map = new IP4Map();
+            $object->_ip4Map->unresolved[$object->name] = $object;
         }
-        elseif( $this->type == self::TypeIpNetmask || $this->type == self::TypeIpRange || $this->type == self::TypeIpWildcard )
+        elseif( $object->type == self::TypeIpNetmask || $object->type == self::TypeIpRange || $object->type == self::TypeIpWildcard )
         {
-            if( $this->type == self::TypeIpWildcard )
+            if( $object->type == self::TypeIpWildcard )
             {
-                $array = explode( "/", $this->value() );
+                $array = explode( "/", $object->value() );
                 $address = $array[0];
                 $wildcardmask = $array[1];
 
@@ -499,29 +504,29 @@ class Address
                 {
                     $tmp_value = $address."/".$cidr;
 
-                    $this->_ip4Map = IP4Map::mapFromText($tmp_value);
-                    if( $this->_ip4Map->count() == 0 )
-                        $this->_ip4Map->unresolved[$this->name] = $this->value();
+                    $object->_ip4Map = IP4Map::mapFromText($tmp_value);
+                    if( $object->_ip4Map->count() == 0 )
+                        $object->_ip4Map->unresolved[$object->name] = $object->value();
                 }
                 else
                 {
-                    $this->_ip4Map->unresolved[$this->name] = $this->value();
+                    $object->_ip4Map->unresolved[$object->name] = $object->value();
                 }
 
             }
             else
             {
-                $this->_ip4Map = IP4Map::mapFromText($this->value);
-                if( $this->_ip4Map->count() == 0 )
-                    $this->_ip4Map->unresolved[$this->name] = $this;
+                $object->_ip4Map = IP4Map::mapFromText($object->value);
+                if( $object->_ip4Map->count() == 0 )
+                    $object->_ip4Map->unresolved[$object->name] = $object;
             }
         }
         else
         {
-            derr("unexpected type: ".$this->type() );
+            derr("unexpected type: ".$object->type() );
         }
 
-        return $this->_ip4Map;
+        return $object->_ip4Map;
     }
 
 

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -47,6 +47,7 @@ class AddressGroup
 
     public $filter;
     public $ancestor;
+    public $childancestor;
 
     /**
      * Constructor for AddressGroup. There is little chance that you will ever need that. Look at AddressStore if you want to create an AddressGroup

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -865,10 +865,10 @@ class AddressGroup
                 }
 
                 /** @var AddressGroup $object */
-                $tmpList = $object->expand( $keepGroupsInList, $grpArray );
+                $tmpList = $object->expand( $keepGroupsInList, $grpArray, $RuleReferenceLocation );
 
-                //$ret = array_merge($ret, $tmpList);
-                $ret = $ret + $tmpList;
+                $ret = array_merge($ret, $tmpList);
+                #$ret = $ret + $tmpList;
 
                 unset($tmpList);
                 if( $keepGroupsInList )

--- a/lib/object-classes/AddressGroup.php
+++ b/lib/object-classes/AddressGroup.php
@@ -848,7 +848,7 @@ class AddressGroup
                 if( array_key_exists($serial, $grpArray) )
                 {
                     #mwarning("addressgroup with name: " . $object->name() . " is added as subgroup to addressgroup: " . $this->name() . ", you should review your XML config file", $object->xmlroot, false, false);
-                    return $ret;
+                    #return $ret;
                 }
                 else
                 {

--- a/lib/object-classes/Region.php
+++ b/lib/object-classes/Region.php
@@ -156,7 +156,7 @@ class Region
      * Return an array['start']= startip and ['end']= endip
      * @return IP4Map
      */
-    public function getIP4Mapping()
+    public function getIP4Mapping( $RuleReferenceLocation = null)
     {
         if( isset($this->_ip4Map) )
         {

--- a/lib/object-classes/Region.php
+++ b/lib/object-classes/Region.php
@@ -188,5 +188,22 @@ class Region
         return "region";
     }
 
+    /**
+     * @param $otherObject Region
+     * @return bool
+     */
+    public function equals($otherObject)
+    {
+        if( !$otherObject->isRegion() )
+            return FALSE;
+
+        if( $otherObject->name != $this->name )
+            return FALSE;
+
+        //Todo: same value of Region objects
+        #return $this->sameValue($otherObject);
+        return False;
+    }
+
     static protected $templatexml = '<entry name="**temporarynamechangeme**"><address><member>tempvaluechangeme</member></entry>';
 }

--- a/lib/object-classes/Region.php
+++ b/lib/object-classes/Region.php
@@ -180,5 +180,13 @@ class Region
         return $this->members;
     }
 
+    /**
+     * @return string ie: 'ip-netmask' 'ip-range'
+     */
+    public function type()
+    {
+        return "region";
+    }
+
     static protected $templatexml = '<entry name="**temporarynamechangeme**"><address><member>tempvaluechangeme</member></entry>';
 }

--- a/lib/object-classes/ServiceGroup.php
+++ b/lib/object-classes/ServiceGroup.php
@@ -657,9 +657,17 @@ class ServiceGroup
      * @param bool $keepGroupsInList
      * @return Service[]|ServiceGroup[] list of all member objects, if some of them are groups, they are exploded and their members inserted
      */
-    public function &expand($keepGroupsInList = FALSE, &$grpArray=array())
+    public function &expand($keepGroupsInList = FALSE, &$grpArray=array(), $RuleReferenceLocation = null )
     {
         $ret = array();
+
+        $grpArray[$this->name()] = $this;
+
+        if( $RuleReferenceLocation !== null )
+        {
+            foreach( $this->members as $key => $member )
+                $this->members[$key] = $RuleReferenceLocation->serviceStore->find($member->name());
+        }
 
         foreach( $this->members as $object )
         {
@@ -669,8 +677,8 @@ class ServiceGroup
             {
                 if( array_key_exists($serial, $grpArray) )
                 {
-                    mwarning("servicegroup with name: " . $object->name() . " is added as subgroup to servicegroup: " . $this->name() . ", you should review your XML config file", $object->xmlroot, false);
-                    return $ret;
+                    #mwarning("servicegroup with name: " . $object->name() . " is added as subgroup to servicegroup: " . $this->name() . ", you should review your XML config file", $object->xmlroot, false);
+                    #return $ret;
                 }
                 else
                     $grpArray[$serial] = $serial;
@@ -682,7 +690,7 @@ class ServiceGroup
                 }
 
                 /** @var ServiceGroup $object */
-                $tmpList = $object->expand( $keepGroupsInList, $grpArray);
+                $tmpList = $object->expand( $keepGroupsInList, $grpArray, $RuleReferenceLocation);
 
                 $ret = array_merge($ret, $tmpList);
                 unset($tmpList);

--- a/lib/object-classes/ServiceStore.php
+++ b/lib/object-classes/ServiceStore.php
@@ -202,6 +202,7 @@ class ServiceStore
                             unset($tmpGroupDeps[$groupName]);
                     }
                 }
+                /*
                 elseif( count($groupDependencies) == 1 )
                 {
                     unset($sortingArray[$groupName]);
@@ -218,6 +219,7 @@ class ServiceStore
                             unset($tmpGroupDeps[$groupName]);
                     }
                 }
+                */
             }
 
             $loopCount++;

--- a/lib/rule-classes/Rule.php
+++ b/lib/rule-classes/Rule.php
@@ -1799,7 +1799,7 @@ class Rule
             }
     }
 
-    public function ServiceResolveSummary()
+    public function ServiceResolveSummary( $RuleReferenceLocation = null )
     {
         $port_mapping_text = array();
 
@@ -1843,6 +1843,12 @@ class Rule
 
 
         $objects = $this->services->getAll();
+
+        if( $RuleReferenceLocation !== null )
+        {
+            foreach( $objects as $key => $member )
+                $objects[$key] = $RuleReferenceLocation->serviceStore->find($member->name());
+        }
 
         $array = array();
         foreach( $objects as $object )

--- a/utils/common/AddressCallContext.php
+++ b/utils/common/AddressCallContext.php
@@ -21,8 +21,6 @@
 class AddressCallContext extends CallContext
 {
     /** @var  Address|AddressGroup */
-    public $object;
-    public $objectList;
 
     public static $commonActionFunctions = array();
     public static $supportedActions = array();

--- a/utils/common/ApplicationCallContext.php
+++ b/utils/common/ApplicationCallContext.php
@@ -21,7 +21,6 @@
 class ApplicationCallContext extends CallContext
 {
     /** @var  App */
-    public $object;
 
     public $counter_containers;
     public $tmpcounter;

--- a/utils/common/CallContext.php
+++ b/utils/common/CallContext.php
@@ -26,6 +26,7 @@ class CallContext
 
     /** @var  Rule|SecurityRule|NatRule|DecryptionRule|AppOverrideRule|CaptivePortalRule|PbfRule|QoSRule|DoSRule $object */
     public $object;
+    public $objectList;
 
     public $actionRef;
 

--- a/utils/common/CallContext.php
+++ b/utils/common/CallContext.php
@@ -278,4 +278,36 @@ class CallContext
 
         return $ret;
     }
+
+    public function encloseFunction( $value, $nowrap = TRUE )
+    {
+        if( is_string($value) )
+            $output = htmlspecialchars($value);
+        elseif( is_array($value) )
+        {
+            $output = '';
+            $first = TRUE;
+            foreach( $value as $subValue )
+            {
+                if( !$first )
+                {
+                    $output .= '<br />';
+                }
+                else
+                    $first = FALSE;
+
+                if( is_string($subValue) )
+                    $output .= htmlspecialchars($subValue);
+                else
+                    $output .= htmlspecialchars($subValue->name());
+            }
+        }
+        else
+            derr('unsupported');
+
+        if( $nowrap )
+            return '<td style="white-space: nowrap">' . $output . '</td>';
+
+        return '<td>' . $output . '</td>';
+    }
 }

--- a/utils/common/DHCPCallContext.php
+++ b/utils/common/DHCPCallContext.php
@@ -23,7 +23,7 @@ class DHCPCallContext extends CallContext
 {
     /** @var  DHCP */
     public $object;
-
+    public $objectList;
 
 
     public static $commonActionFunctions = Array();

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1424,6 +1424,13 @@ AddressCallContext::$supportedActions[] = array(
             return;
         }
 
+        if( $object->isRegion() )
+        {
+            $string = "this is a Region object - not supported yet";
+            PH::ACTIONstatus( $context, "SKIPPED", $string );
+            return;
+        }
+
         $localLocation = 'shared';
 
         if( !$object->owner->owner->isPanorama() && !$object->owner->owner->isFirewall() )

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -794,38 +794,6 @@ AddressCallContext::$supportedActions[] = array(
             $headers .= '<th>nested members count</th>';
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    elseif( is_object($subValue) )
-                        $output .= htmlspecialchars($subValue->name());
-                    else
-                        $output .= htmlspecialchars("-null-");
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
         $count = 0;
         if( isset($context->objectList) )
@@ -840,60 +808,60 @@ AddressCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
                 if( $object->owner->owner->isPanorama() || $object->owner->owner->isFirewall() )
-                    $lines .= $encloseFunction('shared');
+                    $lines .= $context->encloseFunction('shared');
                 else
-                    $lines .= $encloseFunction($object->owner->owner->name());
+                    $lines .= $context->encloseFunction($object->owner->owner->name());
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                 if( $object->isGroup() )
                 {
                     if( $object->isDynamic() )
                     {
-                        $lines .= $encloseFunction('group-dynamic');
-                        #$lines .= $encloseFunction('');
-                        $lines .= $encloseFunction($object->members());
+                        $lines .= $context->encloseFunction('group-dynamic');
+                        #$lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction($object->members());
                     }
                     else
                     {
-                        $lines .= $encloseFunction('group-static');
-                        $lines .= $encloseFunction($object->members());
+                        $lines .= $context->encloseFunction('group-static');
+                        $lines .= $context->encloseFunction($object->members());
                     }
-                    $lines .= $encloseFunction($object->description(), FALSE);
+                    $lines .= $context->encloseFunction($object->description(), FALSE);
                     if( $object->isGroup() )
-                        $lines .= $encloseFunction( (string)count( $object->members() ));
+                        $lines .= $context->encloseFunction( (string)count( $object->members() ));
                     else
-                        $lines .= $encloseFunction( '---' );
+                        $lines .= $context->encloseFunction( '---' );
 
                     $counter = 0;
                     $members = $object->expand(FALSE);
                     foreach( $members as $member )
                         $counter += $member->getIPcount();
-                    $lines .= $encloseFunction((string)$counter);
+                    $lines .= $context->encloseFunction((string)$counter);
 
-                    $lines .= $encloseFunction($object->tags->tags());
+                    $lines .= $context->encloseFunction($object->tags->tags());
                 }
                 elseif( $object->isAddress() )
                 {
                     if( $object->isTmpAddr() )
                     {
-                        $lines .= $encloseFunction('unknown');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('unknown');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                     }
                     else
                     {
-                        $lines .= $encloseFunction($object->type());
-                        $lines .= $encloseFunction($object->value());
-                        $lines .= $encloseFunction($object->description(), FALSE);
-                        $lines .= $encloseFunction( '---' );
-                        $lines .= $encloseFunction( (string)$object->getIPcount() );
-                        $lines .= $encloseFunction($object->tags->tags());
+                        $lines .= $context->encloseFunction($object->type());
+                        $lines .= $context->encloseFunction($object->value());
+                        $lines .= $context->encloseFunction($object->description(), FALSE);
+                        $lines .= $context->encloseFunction( '---' );
+                        $lines .= $context->encloseFunction( (string)$object->getIPcount() );
+                        $lines .= $context->encloseFunction($object->tags->tags());
                     }
                 }
                 elseif( $object->isRegion() )
@@ -908,7 +876,7 @@ AddressCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -919,7 +887,7 @@ AddressCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addResolveGroupIPCoverage )
                 {
@@ -929,17 +897,17 @@ AddressCallContext::$supportedActions[] = array(
                     foreach( array_keys($mapping->unresolved) as $unresolved )
                         $strMapping[] = $unresolved;
 
-                    $lines .= $encloseFunction($strMapping);
+                    $lines .= $context->encloseFunction($strMapping);
                 }
                 if( $addNestedMembers )
                 {
                     if( $object->isGroup() )
                     {
                         $members = $object->expand(FALSE);
-                        $lines .= $encloseFunction($members);
+                        $lines .= $context->encloseFunction($members);
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
                 if( $addResolveIPNestedMembers )
                 {
@@ -948,20 +916,20 @@ AddressCallContext::$supportedActions[] = array(
                         $members = $object->expand(FALSE);
                         foreach( $members as $member )
                             $resolve[] = $member->value();
-                        $lines .= $encloseFunction($resolve);
+                        $lines .= $context->encloseFunction($resolve);
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
                 if( $addNestedMembersCount )
                 {
                     if( $object->isGroup() )
                     {   $resolve = array();
                         $members = $object->expand(FALSE);
-                        $lines .= $encloseFunction( (string)count($members) );
+                        $lines .= $context->encloseFunction( (string)count($members) );
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -810,10 +810,16 @@ AddressCallContext::$supportedActions[] = array(
 
                 $lines .= $context->encloseFunction( (string)$count );
 
-                if( $object->owner->owner->isPanorama() || $object->owner->owner->isFirewall() )
-                    $lines .= $context->encloseFunction('shared');
+                if( isset($object->owner) && isset($object->owner->owner) )
+                {
+                    if($object->owner->owner->isPanorama() || $object->owner->owner->isFirewall() )
+                        $lines .= $context->encloseFunction('shared');
+                    else
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
+                }
                 else
-                    $lines .= $context->encloseFunction($object->owner->owner->name());
+                    $lines .= $context->encloseFunction("---");
+
 
                 $lines .= $context->encloseFunction($object->name());
 

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -697,7 +697,8 @@ AddressCallContext::$supportedActions[] = array(
         }
 
         /** @var AddressGroup $object */
-        $members = $object->expand();
+        $tmp_array = array();
+        $members = $object->expand(FALSE,$tmp_array, $object->owner->owner);
         $mapping = new IP4Map();
 
         $listOfNotConvertibleObjects = array();
@@ -757,6 +758,7 @@ AddressCallContext::$supportedActions[] = array(
         $addResolveGroupIPCoverage = FALSE;
         $addNestedMembers = FALSE;
         $addResolveIPNestedMembers = FALSE;
+        $addResolveLocationNestedMembers = FALSE;
         $addNestedMembersCount = FALSE;
 
         $optionalFields = &$context->arguments['additionalFields'];
@@ -774,6 +776,7 @@ AddressCallContext::$supportedActions[] = array(
         {
             $addNestedMembers = TRUE;
             $addResolveIPNestedMembers = TRUE;
+            $addResolveLocationNestedMembers = TRUE;
             $addNestedMembersCount = TRUE;
         }
 
@@ -790,6 +793,8 @@ AddressCallContext::$supportedActions[] = array(
             $headers .= '<th>nested members</th>';
         if( $addResolveIPNestedMembers )
             $headers .= '<th>nested members ip resolution</th>';
+        if( $addResolveLocationNestedMembers )
+            $headers .= '<th>nested members location resolution</th>';
         if( $addNestedMembersCount )
             $headers .= '<th>nested members count</th>';
 
@@ -843,7 +848,7 @@ AddressCallContext::$supportedActions[] = array(
                         $lines .= $context->encloseFunction( '---' );
 
                     $counter = 0;
-                    $members = $object->expand(FALSE);
+                    $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                     foreach( $members as $member )
                         $counter += $member->getIPcount();
                     $lines .= $context->encloseFunction((string)$counter);
@@ -909,7 +914,8 @@ AddressCallContext::$supportedActions[] = array(
                 {
                     if( $object->isGroup() )
                     {
-                        $members = $object->expand(FALSE);
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         $lines .= $context->encloseFunction($members);
                     }
                     else
@@ -919,9 +925,29 @@ AddressCallContext::$supportedActions[] = array(
                 {
                     if( $object->isGroup() )
                     {   $resolve = array();
-                        $members = $object->expand(FALSE);
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         foreach( $members as $member )
                             $resolve[] = $member->value();
+                        $lines .= $context->encloseFunction($resolve);
+                    }
+                    else
+                        $lines .= $context->encloseFunction('');
+                }
+                if( $addResolveLocationNestedMembers )
+                {
+                    if( $object->isGroup() )
+                    {   $resolve = array();
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
+                        foreach( $members as $member )
+                        {
+                            $tmp_name = $member->owner->owner->name();
+                            if( empty($tmp_name) )
+                                $tmp_name = "shared";
+                            $resolve[] = $tmp_name;
+                        }
+
                         $lines .= $context->encloseFunction($resolve);
                     }
                     else
@@ -931,7 +957,8 @@ AddressCallContext::$supportedActions[] = array(
                 {
                     if( $object->isGroup() )
                     {   $resolve = array();
-                        $members = $object->expand(FALSE);
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         $lines .= $context->encloseFunction( (string)count($members) );
                     }
                     else

--- a/utils/common/actions-device.php
+++ b/utils/common/actions-device.php
@@ -730,36 +730,6 @@ DeviceCallContext::$supportedActions['exportToExcel'] = array(
             $filename = "project/html/".$filename;
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
 
         $addWhereUsed = FALSE;
@@ -795,15 +765,15 @@ DeviceCallContext::$supportedActions['exportToExcel'] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
-                #$lines .= $encloseFunction(PH::getLocationString($object));
+                #$lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                 if( get_class($object) == "TemplateStack" )
                 {
-                    $lines .= $encloseFunction( array_reverse($object->templates) );
+                    $lines .= $context->encloseFunction( array_reverse($object->templates) );
                 }
 
                 if( $addWhereUsed )
@@ -812,7 +782,7 @@ DeviceCallContext::$supportedActions['exportToExcel'] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -823,7 +793,7 @@ DeviceCallContext::$supportedActions['exportToExcel'] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
 
                 $lines .= "</tr>\n";
@@ -1497,41 +1467,6 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                     $filename = "project/html/".$filename;
 
                 $lines = '';
-                $encloseFunction = function ($value, $nowrap = TRUE) {
-                    if( is_string($value) )
-                        $output = htmlspecialchars($value);
-                    elseif( is_array($value) )
-                    {
-                        $output = '';
-                        $first = TRUE;
-                        foreach( $value as $subValue )
-                        {
-                            if( !$first )
-                            {
-                                $output .= '<br />';
-                            }
-                            else
-                                $first = FALSE;
-
-                            if( is_string($subValue) )
-                                $output .= htmlspecialchars($subValue);
-                            else
-                                $output .= htmlspecialchars($subValue->name());
-                        }
-                    }
-                    else
-                    {
-                        #derr('unsupported');
-                        $output = 'unsupported value/type';
-                    }
-
-
-                    if( $nowrap )
-                        return '<td style="white-space: nowrap">' . $output . '</td>';
-
-                    return '<td>' . $output . '</td>';
-                };
-
 
                 $headers = '<th>sub</th><th>ruletype</th>';
                 foreach( $context->fields as $fieldName => $fieldID )
@@ -1553,10 +1488,10 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                                 else
                                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                                #$lines .= $encloseFunction(PH::getLocationString($object));
+                                #$lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                                $lines .= $encloseFunction( strval($subtype) );
-                                $lines .= $encloseFunction( strval($keyruletype) ) ;
+                                $lines .= $context->encloseFunction( strval($subtype) );
+                                $lines .= $context->encloseFunction( strval($keyruletype) ) ;
 
 
                                 if( is_object( $rule['rule'] ) )
@@ -1564,13 +1499,13 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                                     $line = "";
                                     foreach( $context->fields as $fieldName => $fieldID )
                                         $line .= $context->ruleContext->ruleFieldHtmlExport($rule['rule'], $fieldID);
-                                    #$lines .= $encloseFunction( $line );
+                                    #$lines .= $context->encloseFunction( $line );
                                     $lines .= $line;
 
-                                    #$lines .= $encloseFunction( $rule['rule']->name() );
+                                    #$lines .= $context->encloseFunction( $rule['rule']->name() );
                                 }
                                 else
-                                    $lines .= $encloseFunction( $rule['rule'] );
+                                    $lines .= $context->encloseFunction( $rule['rule'] );
 
                                 $lines .= "</tr>\n";
 
@@ -1582,8 +1517,8 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                                     else
                                         $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                                    $lines .= $encloseFunction( "---" );
-                                    $lines .= $encloseFunction( "shadowed" ) ;
+                                    $lines .= $context->encloseFunction( "---" );
+                                    $lines .= $context->encloseFunction( "shadowed" ) ;
 
 
 
@@ -1592,14 +1527,14 @@ DeviceCallContext::$supportedActions['display-shadowrule'] = array(
                                         $line = "";
                                         foreach( $context->fields as $fieldName => $fieldID )
                                             $line .= $context->ruleContext->ruleFieldHtmlExport($ruleItem, $fieldID);
-                                        #$lines .= $encloseFunction( $line );
+                                        #$lines .= $context->encloseFunction( $line );
                                         $lines .= $line;
 
-                                        #$lines .= $encloseFunction( $ruleItem->name() );
+                                        #$lines .= $context->encloseFunction( $ruleItem->name() );
                                     }
 
                                     else
-                                        $lines .= $encloseFunction( strval($ruleItem) );
+                                        $lines .= $context->encloseFunction( strval($ruleItem) );
 
                                     $lines .= "</tr>\n";
                                 }

--- a/utils/common/actions-dhcp.php
+++ b/utils/common/actions-dhcp.php
@@ -89,3 +89,143 @@ DHCPCallContext::$supportedActions['dhcp-server-reservation-create'] = Array(
         'mac' => array('type' => 'string', 'default' => 'false'),
     ),
 );
+
+DHCPCallContext::$supportedActions['exportToExcel'] = array(
+    'name' => 'exportToExcel',
+    'MainFunction' => function (DHCPCallContext $context) {
+        $object = $context->object;
+        $context->objectList[] = $object;
+    },
+    'GlobalInitFunction' => function (DHCPCallContext $context) {
+        $context->objectList = array();
+    },
+    'GlobalFinishFunction' => function (DHCPCallContext $context) {
+        $args = &$context->arguments;
+        $filename = $args['filename'];
+
+        if( isset( $_SERVER['REQUEST_METHOD'] ) )
+            $filename = "project/html/".$filename;
+
+        $addWhereUsed = FALSE;
+        $addUsedInLocation = FALSE;
+
+        $optionalFields = &$context->arguments['additionalFields'];
+
+        if( isset($optionalFields['WhereUsed']) )
+            $addWhereUsed = TRUE;
+
+        if( isset($optionalFields['UsedInLocation']) )
+            $addUsedInLocation = TRUE;
+
+        $headers = '<th>ID</th><th>template</th><th>location</th><th>name</th>';
+        $headers .= '<th>Reservation</th>';
+
+        if( $addWhereUsed )
+            $headers .= '<th>where used</th>';
+        if( $addUsedInLocation )
+            $headers .= '<th>location used</th>';
+
+
+        $lines = '';
+
+        $count = 0;
+        if( isset($context->objectList) )
+        {
+            foreach( $context->objectList as $object )
+            {
+                $count++;
+
+                /** @var DHCP $object */
+                if( $count % 2 == 1 )
+                    $lines .= "<tr>\n";
+                else
+                    $lines .= "<tr bgcolor=\"#DDDDDD\">";
+
+                $lines .= $context->encloseFunction((string)$count);
+
+                if( $context->subSystem->isPanorama() )
+                {
+                    if( $object->owner->owner->owner->owner !== null && get_class($object->owner->owner->owner->owner) == "Template" )
+                    {
+                        $lines .= $context->encloseFunction($object->owner->owner->owner->owner->name());
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
+                    }
+                    else
+                    {
+                        $lines .= $context->encloseFunction("");
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
+                    }
+                }
+                else
+                {
+                    $lines .= $context->encloseFunction("");
+                    $lines .= $context->encloseFunction($object->owner->owner->name());
+                }
+
+
+                $lines .= $context->encloseFunction($object->name());
+
+                $tmpString = "";
+                foreach( $object->server_leases as $lease )
+                    $tmpString .= $lease['ip']." | ".$lease['mac'];
+                $lines .= $context->encloseFunction($tmpString);
+
+                if( $addWhereUsed )
+                {
+                    $refTextArray = array();
+                    foreach( $object->getReferences() as $ref )
+                        $refTextArray[] = $ref->_PANC_shortName();
+
+                    $lines .= $context->encloseFunction($refTextArray);
+                }
+                if( $addUsedInLocation )
+                {
+                    $refTextArray = array();
+                    foreach( $object->getReferences() as $ref )
+                    {
+                        $location = PH::getLocationString($object->owner);
+                        $refTextArray[$location] = $location;
+                    }
+
+                    $lines .= $context->encloseFunction($refTextArray);
+                }
+
+
+                $lines .= "</tr>\n";
+
+            }
+        }
+
+        $content = file_get_contents(dirname(__FILE__) . '/html/export-template.html');
+        $content = str_replace('%TableHeaders%', $headers, $content);
+
+        $content = str_replace('%lines%', $lines, $content);
+
+        $jscontent = file_get_contents(dirname(__FILE__) . '/html/jquery.min.js');
+        $jscontent .= "\n";
+        $jscontent .= file_get_contents(dirname(__FILE__) . '/html/jquery.stickytableheaders.min.js');
+        $jscontent .= "\n\$('table').stickyTableHeaders();\n";
+
+        $content = str_replace('%JSCONTENT%', $jscontent, $content);
+
+        file_put_contents($filename, $content);
+
+
+        file_put_contents($filename, $content);
+    },
+    'args' => array('filename' => array('type' => 'string', 'default' => '*nodefault*'),
+        'additionalFields' =>
+            array('type' => 'pipeSeparatedList',
+                'subtype' => 'string',
+                'default' => '*NONE*',
+                'choices' => array('WhereUsed', 'UsedInLocation', 'ResolveIP', 'NestedMembers'),
+                'help' =>
+                    "pipe(|) separated list of additional fields (ie: Arg1|Arg2|Arg3...) to include in the report. The following is available:\n" .
+                    "  - NestedMembers: lists all members, even the ones that may be included in nested groups\n" .
+                    "  - ResolveIP\n" .
+                    "  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n" .
+                    "  - WhereUsed : list places where object is used (rules, groups ...)\n"
+            )
+    )
+
+);

--- a/utils/common/actions-dhcp.php
+++ b/utils/common/actions-dhcp.php
@@ -181,17 +181,17 @@ DHCPCallContext::$supportedActions['exportToExcel'] = array(
 
                 $lines .= $context->encloseFunction((string)$count);
 
-                if( get_class($context->subSystem) == "PANConf" )
+                if( get_class($object->owner->owner) == "PANConf" )
                 {
-                    if( isset($context->subSystem->owner) && $context->subSystem->owner !== null && (get_class($context->subSystem->owner) == "Template" || get_class($context->subSystem->owner) == "TemplateStack" ) )
+                    if( isset($object->owner->owner->owner) && $object->owner->owner->owner !== null && (get_class($object->owner->owner->owner) == "Template" || get_class($context->subSystem->owner) == "TemplateStack" ) )
                     {
-                        $lines .= $context->encloseFunction($context->subSystem->owner->name());
-                        $lines .= $context->encloseFunction($context->subSystem->name());
+                        $lines .= $context->encloseFunction($object->owner->owner->owner->name());
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
                     }
                     else
                     {
                         $lines .= $context->encloseFunction("---");
-                        $lines .= $context->encloseFunction($context->subSystem->name());
+                        $lines .= $context->encloseFunction($context->owner->owner->name());
                     }
                 }
 

--- a/utils/common/actions-dhcp.php
+++ b/utils/common/actions-dhcp.php
@@ -191,7 +191,7 @@ DHCPCallContext::$supportedActions['exportToExcel'] = array(
                     else
                     {
                         $lines .= $context->encloseFunction("---");
-                        $lines .= $context->encloseFunction($context->owner->owner->name());
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
                     }
                 }
 

--- a/utils/common/actions-dhcp.php
+++ b/utils/common/actions-dhcp.php
@@ -143,23 +143,18 @@ DHCPCallContext::$supportedActions['exportToExcel'] = array(
 
                 $lines .= $context->encloseFunction((string)$count);
 
-                if( $context->subSystem->isPanorama() )
+                if( get_class($context->subSystem) == "PANConf" )
                 {
-                    if( $object->owner->owner->owner->owner !== null && get_class($object->owner->owner->owner->owner) == "Template" )
+                    if( isset($context->subSystem->owner) && $context->subSystem->owner !== null && (get_class($context->subSystem->owner) == "Template" || get_class($context->subSystem->owner) == "TemplateStack" ) )
                     {
-                        $lines .= $context->encloseFunction($object->owner->owner->owner->owner->name());
-                        $lines .= $context->encloseFunction($object->owner->owner->name());
+                        $lines .= $context->encloseFunction($context->subSystem->owner->name());
+                        $lines .= $context->encloseFunction($context->subSystem->name());
                     }
                     else
                     {
-                        $lines .= $context->encloseFunction("");
-                        $lines .= $context->encloseFunction($object->owner->owner->name());
+                        $lines .= $context->encloseFunction("---");
+                        $lines .= $context->encloseFunction($context->subSystem->name());
                     }
-                }
-                else
-                {
-                    $lines .= $context->encloseFunction("");
-                    $lines .= $context->encloseFunction($object->owner->owner->name());
                 }
 
 

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -4300,36 +4300,6 @@ RuleCallContext::$supportedActions[] = array(
         if( isset( $_SERVER['REQUEST_METHOD'] ) )
             $filename = "project/html/".$filename;
 
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
         $addResolvedAddressSummary = FALSE;
         $addResolvedServiceSummary = FALSE;
@@ -4430,7 +4400,7 @@ RuleCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
                 foreach( $fields as $fieldName => $fieldID )
                 {

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -3823,7 +3823,7 @@ RuleCallContext::$supportedActions[] = array(
             if( $addResolvedAddressSummary )
             {
                 $unresolvedArray = array();
-                PH::$JSON_TMP['sub']['object'][$rule->name()]['src_resolved_sum']['resolved'] = $context->AddressResolveSummary( $rule, "source", $unresolvedArray );
+                PH::$JSON_TMP['sub']['object'][$rule->name()]['src_resolved_sum']['resolved'] = $context->AddressResolveSummaryNEW( $rule, "source", $unresolvedArray );
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['src_resolved_sum']['unresolved'] = $unresolvedArray;
                 $unresolvedArray = array();
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['src_resolved_value'] = $context->AddressResolveValueSummary( $rule, "source", $unresolvedArray );
@@ -3833,7 +3833,7 @@ RuleCallContext::$supportedActions[] = array(
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['src_resolved_nested_value'] = $context->AddressResolveValueNestedSummary( $rule, "source", $unresolvedArray );
 
                 $unresolvedArray = array();
-                PH::$JSON_TMP['sub']['object'][$rule->name()]['dst_resolved_sum']['resolved'] = $context->AddressResolveSummary( $rule, "destination", $unresolvedArray );
+                PH::$JSON_TMP['sub']['object'][$rule->name()]['dst_resolved_sum']['resolved'] = $context->AddressResolveSummaryNEW( $rule, "destination", $unresolvedArray );
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['dst_resolved_sum']['unresolved'] = $unresolvedArray;
                 $unresolvedArray = array();
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['dst_resolved_value'] = $context->AddressResolveValueSummary( $rule, "destination", $unresolvedArray );
@@ -4344,6 +4344,7 @@ RuleCallContext::$supportedActions[] = array(
             'src' => 'source',
             'src_resolved_value' => 'src_resolved_value',
             'src_resolved_sum' => 'src_resolved_sum',
+            'src_resolved_sumOLD' => 'src_resolved_sumOLD',
             'src_resolved_nested_name' => 'src_resolved_nested_name',
             'src_resolved_nested_value' => 'src_resolved_nested_value',
             'src_resolved_nested_location' => 'src_resolved_nested_location',
@@ -4352,6 +4353,7 @@ RuleCallContext::$supportedActions[] = array(
             'dst_interface' => 'dst_interface',
             'dst_resolved_value' => 'dst_resolved_value',
             'dst_resolved_sum' => 'dst_resolved_sum',
+            'dst_resolved_sumOLD' => 'dst_resolved_sumOLD',
             'dst_resolved_nested_name' => 'dst_resolved_nested_name',
             'dst_resolved_nested_value' => 'dst_resolved_nested_value',
             'dst_resolved_nested_location' => 'dst_resolved_nested_location',
@@ -4413,9 +4415,9 @@ RuleCallContext::$supportedActions[] = array(
                 foreach( $fields as $fieldName => $fieldID )
                 {
                         if( ((
-                            $fieldName == 'src_resolved_sum' || $fieldName == 'src_resolved_value' ||
+                            $fieldName == 'src_resolved_sum' || $fieldName == 'src_resolved_sumOLD' || $fieldName == 'src_resolved_value' ||
                             $fieldName == 'src_resolved_nested_name' || $fieldName == 'src_resolved_nested_value' || $fieldName == 'src_resolved_nested_location' ||
-                            $fieldName == 'dst_resolved_sum' || $fieldName == 'dst_resolved_value' ||
+                            $fieldName == 'dst_resolved_sum' || $fieldName == 'dst_resolved_sumOLD' || $fieldName == 'dst_resolved_value' ||
                             $fieldName == 'dst_resolved_nested_name' || $fieldName == 'dst_resolved_nested_value' || $fieldName == 'dst_resolved_nested_location' ||
                             $fieldName == 'dnat_host_resolved_sum' ||
                             $fieldName == 'snat_address_resolved_sum')

--- a/utils/common/actions-rule.php
+++ b/utils/common/actions-rule.php
@@ -3844,7 +3844,12 @@ RuleCallContext::$supportedActions[] = array(
             }
 
             if( $addResolvedServiceSummary )
-                PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_resolved_sum'] = $rule->ServiceResolveSummary();
+            {
+                PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_resolved_sum'] = $rule->ServiceResolveSummary($rule->owner->owner);
+                PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_resolved_nested_name'] = $context->ServiceResolveNameNestedSummary( $rule );
+                PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_resolved_nested_value'] = $context->ServiceResolveValueNestedSummary( $rule );
+            }
+
 
             if( $addResolvedServiceAppDefaultSummary )
                 PH::$JSON_TMP['sub']['object'][$rule->name()]['srv_appdefault_resolved_sum'] = $rule->ServiceAppDefaultResolveSummary();
@@ -4352,6 +4357,9 @@ RuleCallContext::$supportedActions[] = array(
             'dst_resolved_nested_location' => 'dst_resolved_nested_location',
             'service' => 'service',
             'service_resolved_sum' => 'service_resolved_sum',
+            'service_resolved_nested_name' => 'service_resolved_nested_name',
+            'service_resolved_nested_value' => 'service_resolved_nested_value',
+            'service_resolved_nested_location' => 'service_resolved_nested_location',
             'service_appdefault_resolved_sum' => 'service_appdefault_resolved_sum',
             'service_count' => 'service_count',
             'service_count_tcp' => 'service_count_tcp',
@@ -4413,10 +4421,11 @@ RuleCallContext::$supportedActions[] = array(
                             $fieldName == 'snat_address_resolved_sum')
                             && !$addResolvedAddressSummary) ||
                         (($fieldName == 'service_resolved_sum' ||
+                                $fieldName == 'service_resolved_nested_name' || $fieldName == 'service_resolved_nested_value' || $fieldName == 'service_resolved_nested_location' ||
                                 $fieldName == 'service_count' || $fieldName == 'service_count_tcp' || $fieldName == 'service_count_udp') && !$addResolvedServiceSummary) ||
                         (($fieldName == 'service_appdefault_resolved_sum') && !$addResolvedServiceAppDefaultSummary) ||
                         (($fieldName == 'application_resolved_sum') && !$addResolvedApplicationSummary) ||
-                        (($fieldName == 'schedule_resolved_sum') && !$addResolvedScheduleSummary) ||
+                        (($fieldName == 'schedule_resolved_sum' ) && !$addResolvedScheduleSummary) ||
                         (($fieldName == 'application_seen') && (!$addAppSeenSummary || !$context->isAPI) ) ||
                         (($fieldName == 'first-hit' || $fieldName == 'last-hit' || $fieldName == 'hit-count') && (!$addHitCountSummary || !$context->isAPI) ) ||
                         (($fieldName == 'nat_rule_type' || $fieldName == 'snat_type' || $fieldName == 'snat_address' ||

--- a/utils/common/actions-securityprofile.php
+++ b/utils/common/actions-securityprofile.php
@@ -469,36 +469,6 @@ SecurityProfileCallContext::$supportedActions[] = array(
 
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
         $count = 0;
         if( isset($context->objectList) )
@@ -513,32 +483,32 @@ SecurityProfileCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
                 if( $object->owner->owner === null )
                 {
-                    $lines .= $encloseFunction('predefined');
+                    $lines .= $context->encloseFunction('predefined');
                 }
                 else
                 {
                     if( $object->owner->owner !== null && ( $object->owner->owner->isPanorama() || $object->owner->owner->isFirewall() ) )
-                        $lines .= $encloseFunction('shared');
+                        $lines .= $context->encloseFunction('shared');
                     else
-                        $lines .= $encloseFunction($object->owner->owner->name());
+                        $lines .= $context->encloseFunction($object->owner->owner->name());
                 }
 
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
-                $lines .= $encloseFunction( $object->owner->name() );
+                $lines .= $context->encloseFunction( $object->owner->name() );
 
 
                 if( isset($object->secprof_type) )
-                    $lines .= $encloseFunction($object->secprof_type);
+                    $lines .= $context->encloseFunction($object->secprof_type);
                 else
-                    $lines .= $encloseFunction(get_class($object) );
+                    $lines .= $context->encloseFunction(get_class($object) );
 
-                #$lines .= $encloseFunction($object->value());
+                #$lines .= $context->encloseFunction($object->value());
                 if( !empty( $object->threatException ) )
                 {
                     $tmp_array = array();
@@ -546,10 +516,10 @@ SecurityProfileCallContext::$supportedActions[] = array(
                         $tmp_array[] = $threatname;
 
                     $string = implode( ",", $tmp_array);
-                    $lines .= $encloseFunction( $string );
+                    $lines .= $context->encloseFunction( $string );
                 }
                 else
-                    $lines .= $encloseFunction('');
+                    $lines .= $context->encloseFunction('');
 
                 if( get_class($object) == "customURLProfile" )
                 {
@@ -561,11 +531,11 @@ SecurityProfileCallContext::$supportedActions[] = array(
                         $tmp_array[] = $member;
 
                     $string = implode( ",", $tmp_array);
-                    $lines .= $encloseFunction( $tmp_array );
+                    $lines .= $context->encloseFunction( $tmp_array );
                 }
                 else
                 {
-                    $lines .= $encloseFunction('');
+                    $lines .= $context->encloseFunction('');
                 }
 
                 if( $addWhereUsed )
@@ -574,7 +544,7 @@ SecurityProfileCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -585,7 +555,7 @@ SecurityProfileCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-securityprofilegroup.php
+++ b/utils/common/actions-securityprofilegroup.php
@@ -228,44 +228,6 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
             $filename = "project/html/".$filename;
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            elseif( is_object($value) )
-                $output = htmlspecialchars($value->name());
-            elseif( $value == null )
-                $output = "---";
-            else
-            {
-                derr('unsupported');
-            }
-
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
-
 
         $addWhereUsed = FALSE;
         $addUsedInLocation = FALSE;
@@ -299,11 +261,11 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
-                $lines .= $encloseFunction(PH::getLocationString($object));
+                $lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                 
                 $counter_array = array();
@@ -311,17 +273,17 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                 if( count( $refLoc ) == 0 )
                 {
                     $refLoc = "---";
-                    $lines .= $encloseFunction($refLoc);
+                    $lines .= $context->encloseFunction($refLoc);
                 }
                 else
                 {
-                    $lines .= $encloseFunction($refLoc);
+                    $lines .= $context->encloseFunction($refLoc);
                 }
 
                 if( count( $counter_array ) == 0 )
                 {
                     $refLoc = "---";
-                    $lines .= $encloseFunction($refLoc);
+                    $lines .= $context->encloseFunction($refLoc);
                 }
                 else
                 {
@@ -330,7 +292,7 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                         $tmparray[$key] = (string)$counter_array[$key];
                     $counter_array = $tmparray;
 
-                    $lines .= $encloseFunction($counter_array);
+                    $lines .= $context->encloseFunction($counter_array);
                 }
 
                 $refCount = $object->countReferences();
@@ -338,23 +300,23 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                     $refCount = "---";
                 else
                     $refCount = (string)$refCount ;
-                $lines .= $encloseFunction( $refCount );
+                $lines .= $context->encloseFunction( $refCount );
 
                 //private $secprof_array = array('virus', 'spyware', 'vulnerability', 'file-blocking', 'wildfire-analysis', 'url-filtering', 'data-filtering');
 
-                $lines .= $encloseFunction($object->secprofiles['virus']);
+                $lines .= $context->encloseFunction($object->secprofiles['virus']);
 
-                $lines .= $encloseFunction($object->secprofiles['spyware']);
+                $lines .= $context->encloseFunction($object->secprofiles['spyware']);
 
-                $lines .= $encloseFunction($object->secprofiles['vulnerability']);
+                $lines .= $context->encloseFunction($object->secprofiles['vulnerability']);
 
-                $lines .= $encloseFunction($object->secprofiles['url-filtering']);
+                $lines .= $context->encloseFunction($object->secprofiles['url-filtering']);
 
-                $lines .= $encloseFunction($object->secprofiles['file-blocking']);
+                $lines .= $context->encloseFunction($object->secprofiles['file-blocking']);
 
-                $lines .= $encloseFunction($object->secprofiles['data-filtering']);
+                $lines .= $context->encloseFunction($object->secprofiles['data-filtering']);
 
-                $lines .= $encloseFunction($object->secprofiles['wildfire-analysis']);
+                $lines .= $context->encloseFunction($object->secprofiles['wildfire-analysis']);
 
                 if( $addWhereUsed )
                 {
@@ -362,7 +324,7 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -373,7 +335,7 @@ SecurityProfileGroupCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -280,38 +280,6 @@ ServiceCallContext::$supportedActions[] = array(
             $headers .= '<th>nested members count</th>';
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    elseif( is_object($subValue) )
-                        $output .= htmlspecialchars($subValue->name());
-                    else
-                        $output .= htmlspecialchars("-null-");
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
         $count = 0;
         if( isset($context->objectList) )
@@ -326,60 +294,60 @@ ServiceCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
-                $lines .= $encloseFunction(PH::getLocationString($object));
+                $lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                 if( $object->isGroup() )
                 {
-                    $lines .= $encloseFunction('group');
-                    $lines .= $encloseFunction('');
-                    $lines .= $encloseFunction('');
-                    $lines .= $encloseFunction('');
-                    $lines .= $encloseFunction($object->members());
-                    $lines .= $encloseFunction( (string)count( $object->members() ));
-                    $lines .= $encloseFunction('');
-                    $lines .= $encloseFunction($object->tags->tags());
+                    $lines .= $context->encloseFunction('group');
+                    $lines .= $context->encloseFunction('');
+                    $lines .= $context->encloseFunction('');
+                    $lines .= $context->encloseFunction('');
+                    $lines .= $context->encloseFunction($object->members());
+                    $lines .= $context->encloseFunction( (string)count( $object->members() ));
+                    $lines .= $context->encloseFunction('');
+                    $lines .= $context->encloseFunction($object->tags->tags());
                 }
                 elseif( $object->isService() )
                 {
                     if( $object->isTmpSrv() )
                     {
-                        $lines .= $encloseFunction('unknown');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction( '---' );
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('unknown');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction( '---' );
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                     }
                     else
                     {
                         if( $object->isTcp() )
-                            $lines .= $encloseFunction('service-tcp');
+                            $lines .= $context->encloseFunction('service-tcp');
                         else
-                            $lines .= $encloseFunction('service-udp');
+                            $lines .= $context->encloseFunction('service-udp');
 
-                        $lines .= $encloseFunction($object->getDestPort());
-                        $lines .= $encloseFunction($object->getSourcePort());
-                        $lines .= $encloseFunction($object->getTimeout());
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction( '---' );
-                        $lines .= $encloseFunction($object->description(), FALSE);
-                        $lines .= $encloseFunction($object->tags->tags());
+                        $lines .= $context->encloseFunction($object->getDestPort());
+                        $lines .= $context->encloseFunction($object->getSourcePort());
+                        $lines .= $context->encloseFunction($object->getTimeout());
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction( '---' );
+                        $lines .= $context->encloseFunction($object->description(), FALSE);
+                        $lines .= $context->encloseFunction($object->tags->tags());
                     }
                 }
 
                 $calculatedCounter = $context->ServiceCount( $object, "both" );
-                $lines .= $encloseFunction((string)$calculatedCounter);
+                $lines .= $context->encloseFunction((string)$calculatedCounter);
 
                 $calculatedCounter = $context->ServiceCount( $object, "tcp" );
-                $lines .= $encloseFunction((string)$calculatedCounter);
+                $lines .= $context->encloseFunction((string)$calculatedCounter);
 
                 $calculatedCounter = $context->ServiceCount( $object, "udp" );
-                $lines .= $encloseFunction((string)$calculatedCounter);
+                $lines .= $context->encloseFunction((string)$calculatedCounter);
 
 
                 if( $addWhereUsed )
@@ -388,7 +356,7 @@ ServiceCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -399,7 +367,7 @@ ServiceCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addResolveGroupSRVCoverage )
                 {
@@ -452,7 +420,7 @@ ServiceCallContext::$supportedActions[] = array(
                         }
                     }
 
-                    $lines .= $encloseFunction($port_mapping_text);
+                    $lines .= $context->encloseFunction($port_mapping_text);
                 }
 
                 if( $addNestedMembers )
@@ -460,10 +428,10 @@ ServiceCallContext::$supportedActions[] = array(
                     if( $object->isGroup() )
                     {
                         $members = $object->expand(FALSE);
-                        $lines .= $encloseFunction($members);
+                        $lines .= $context->encloseFunction($members);
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
                 if( $addResolveSRVNestedMembers )
                 {
@@ -478,20 +446,20 @@ ServiceCallContext::$supportedActions[] = array(
                             $resolve[] = $member->protocol()."/".$member->getDestPort().$srcport;
                         }
 
-                        $lines .= $encloseFunction($resolve);
+                        $lines .= $context->encloseFunction($resolve);
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
                 if( $addNestedMembersCount )
                 {
                     if( $object->isGroup() )
                     {   $resolve = array();
                         $members = $object->expand(FALSE);
-                        $lines .= $encloseFunction( (string)count($members) );
+                        $lines .= $context->encloseFunction( (string)count($members) );
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -315,7 +315,23 @@ ServiceCallContext::$supportedActions[] = array(
                 {
                     if( $object->isTmpSrv() )
                     {
-                        $lines .= $context->encloseFunction('unknown');
+                        if( $object->name() == "service-http" )
+                        {
+                            $lines .= $context->encloseFunction('service-tcp');
+                            $lines .= $context->encloseFunction('40');
+                        }
+                        elseif( $object->name() == "service-https" )
+                        {
+                            $lines .= $context->encloseFunction('service-tcp');
+                            $lines .= $context->encloseFunction('443');
+                        }
+                        else
+                        {
+                            $lines .= $context->encloseFunction('unknown');
+                            $lines .= $context->encloseFunction('');
+                        }
+
+
                         $lines .= $context->encloseFunction('');
                         $lines .= $context->encloseFunction('');
                         $lines .= $context->encloseFunction('');

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -243,6 +243,7 @@ ServiceCallContext::$supportedActions[] = array(
         $addResolveGroupSRVCoverage = FALSE;
         $addNestedMembers = FALSE;
         $addResolveSRVNestedMembers = FALSE;
+        $addResolveLocationNestedMembers = FALSE;
         $addNestedMembersCount = FALSE;
 
         $optionalFields = &$context->arguments['additionalFields'];
@@ -260,6 +261,7 @@ ServiceCallContext::$supportedActions[] = array(
         {
             $addNestedMembers = TRUE;
             $addResolveSRVNestedMembers = TRUE;
+            $addResolveLocationNestedMembers = TRUE;
             $addNestedMembersCount = TRUE;
         }
 
@@ -276,6 +278,9 @@ ServiceCallContext::$supportedActions[] = array(
             $headers .= '<th>nested members</th>';
         if( $addResolveSRVNestedMembers )
             $headers .= '<th>nested members srv resolution</th>';
+        if( $addResolveLocationNestedMembers )
+            $headers .= '<th>nested members location resolution</th>';
+
         if( $addNestedMembersCount )
             $headers .= '<th>nested members count</th>';
 
@@ -443,7 +448,8 @@ ServiceCallContext::$supportedActions[] = array(
                 {
                     if( $object->isGroup() )
                     {
-                        $members = $object->expand(FALSE);
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         $lines .= $context->encloseFunction($members);
                     }
                     else
@@ -452,8 +458,10 @@ ServiceCallContext::$supportedActions[] = array(
                 if( $addResolveSRVNestedMembers )
                 {
                     if( $object->isGroup() )
-                    {   $resolve = array();
-                        $members = $object->expand(FALSE);
+                    {
+                        $resolve = array();
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         foreach( $members as $member )
                         {
                             $srcport = "";
@@ -467,11 +475,30 @@ ServiceCallContext::$supportedActions[] = array(
                     else
                         $lines .= $context->encloseFunction('');
                 }
+                if( $addResolveLocationNestedMembers )
+                {
+                    if( $object->isGroup() )
+                    {   $resolve = array();
+                        $tmp_array = array();
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
+                        foreach( $members as $member )
+                        {
+                            $tmp_name = $member->owner->owner->name();
+                            if( empty($tmp_name) )
+                                $tmp_name = "shared";
+                            $resolve[] = $tmp_name;
+                        }
+
+                        $lines .= $context->encloseFunction($resolve);
+                    }
+                    else
+                        $lines .= $context->encloseFunction('');
+                }
                 if( $addNestedMembersCount )
                 {
                     if( $object->isGroup() )
                     {   $resolve = array();
-                        $members = $object->expand(FALSE);
+                        $members = $object->expand(FALSE, $tmp_array, $object->owner->owner);
                         $lines .= $context->encloseFunction( (string)count($members) );
                     }
                     else

--- a/utils/common/actions-tag.php
+++ b/utils/common/actions-tag.php
@@ -581,36 +581,6 @@ TagCallContext::$supportedActions[] = array(
             $filename = "project/html/".$filename;
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
 
         $addWhereUsed = FALSE;
@@ -645,24 +615,24 @@ TagCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
-                $lines .= $encloseFunction(PH::getLocationString($object));
+                $lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                 if( $object->isTag() )
                 {
                     if( $object->isTmp() )
                     {
-                        $lines .= $encloseFunction('unknown');
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('unknown');
+                        $lines .= $context->encloseFunction('');
 
                     }
                     else
                     {
-                        $lines .= $encloseFunction($object->color);
-                        $lines .= $encloseFunction($object->getComments());
+                        $lines .= $context->encloseFunction($object->color);
+                        $lines .= $context->encloseFunction($object->getComments());
                     }
                 }
 
@@ -672,7 +642,7 @@ TagCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -683,7 +653,7 @@ TagCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-threat.php
+++ b/utils/common/actions-threat.php
@@ -82,37 +82,6 @@ ThreatCallContext::$supportedActions[] = array(
             $filename = "project/html/".$filename;
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
-
 
         $addWhereUsed = FALSE;
         $addUsedInLocation = FALSE;
@@ -146,21 +115,21 @@ ThreatCallContext::$supportedActions[] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
-                $lines .= $encloseFunction(PH::getLocationString($object));
+                $lines .= $context->encloseFunction(PH::getLocationString($object));
 
-                $lines .= $encloseFunction(get_class($object));
+                $lines .= $context->encloseFunction(get_class($object));
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
-                $lines .= $encloseFunction($object->threatname());
+                $lines .= $context->encloseFunction($object->threatname());
 
-                $lines .= $encloseFunction($object->category());
+                $lines .= $context->encloseFunction($object->category());
 
-                $lines .= $encloseFunction($object->severity());
+                $lines .= $context->encloseFunction($object->severity());
 
-                $lines .= $encloseFunction($object->defaultAction());
+                $lines .= $context->encloseFunction($object->defaultAction());
 
                 if( $addWhereUsed )
                 {
@@ -168,7 +137,7 @@ ThreatCallContext::$supportedActions[] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -179,7 +148,7 @@ ThreatCallContext::$supportedActions[] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/common/actions-zone.php
+++ b/utils/common/actions-zone.php
@@ -680,36 +680,6 @@ ZoneCallContext::$supportedActions['exportToExcel'] = array(
             $headers .= '<th>nested members</th>';
 
         $lines = '';
-        $encloseFunction = function ($value, $nowrap = TRUE) {
-            if( is_string($value) )
-                $output = htmlspecialchars($value);
-            elseif( is_array($value) )
-            {
-                $output = '';
-                $first = TRUE;
-                foreach( $value as $subValue )
-                {
-                    if( !$first )
-                    {
-                        $output .= '<br />';
-                    }
-                    else
-                        $first = FALSE;
-
-                    if( is_string($subValue) )
-                        $output .= htmlspecialchars($subValue);
-                    else
-                        $output .= htmlspecialchars($subValue->name());
-                }
-            }
-            else
-                derr('unsupported');
-
-            if( $nowrap )
-                return '<td style="white-space: nowrap">' . $output . '</td>';
-
-            return '<td>' . $output . '</td>';
-        };
 
         $count = 0;
         if( isset($context->objectList) )
@@ -724,45 +694,45 @@ ZoneCallContext::$supportedActions['exportToExcel'] = array(
                 else
                     $lines .= "<tr bgcolor=\"#DDDDDD\">";
 
-                $lines .= $encloseFunction( (string)$count );
+                $lines .= $context->encloseFunction( (string)$count );
 
                 if( $object->owner->owner->owner->owner  !== null && get_class( $object->owner->owner->owner->owner ) == "Template" )
                 {
-                    $lines .= $encloseFunction($object->owner->owner->owner->owner->name());
-                    $lines .= $encloseFunction($object->owner->owner->name());
+                    $lines .= $context->encloseFunction($object->owner->owner->owner->owner->name());
+                    $lines .= $context->encloseFunction($object->owner->owner->name());
                 }
                 else
                 {
-                    $lines .= $encloseFunction( "" );
-                    $lines .= $encloseFunction($object->owner->owner->name());
+                    $lines .= $context->encloseFunction( "" );
+                    $lines .= $context->encloseFunction($object->owner->owner->name());
                 }
 
 
-                $lines .= $encloseFunction($object->name());
+                $lines .= $context->encloseFunction($object->name());
 
                     if( $object->isTmp() )
                     {
-                        $lines .= $encloseFunction('unknown');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('unknown');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                     }
                     else
                     {
-                        $lines .= $encloseFunction($object->type());
-                        $lines .= $encloseFunction( $object->attachedInterfaces->getAll() );
+                        $lines .= $context->encloseFunction($object->type());
+                        $lines .= $context->encloseFunction( $object->attachedInterfaces->getAll() );
 
                         if( $object->logsetting == null )
                             $tmpLogprof = "";
                         else
                             $tmpLogprof = $object->logsetting;
-                        $lines .= $encloseFunction( $tmpLogprof );
+                        $lines .= $context->encloseFunction( $tmpLogprof );
 
                         if( $object->zoneProtectionProfile == null )
                             $tmpZPP = "";
                         else
                             $tmpZPP = $object->zoneProtectionProfile;
-                        $lines .= $encloseFunction( $tmpZPP );
+                        $lines .= $context->encloseFunction( $tmpZPP );
                     }
 
                 if( $addWhereUsed )
@@ -771,7 +741,7 @@ ZoneCallContext::$supportedActions['exportToExcel'] = array(
                     foreach( $object->getReferences() as $ref )
                         $refTextArray[] = $ref->_PANC_shortName();
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addUsedInLocation )
                 {
@@ -782,7 +752,7 @@ ZoneCallContext::$supportedActions['exportToExcel'] = array(
                         $refTextArray[$location] = $location;
                     }
 
-                    $lines .= $encloseFunction($refTextArray);
+                    $lines .= $context->encloseFunction($refTextArray);
                 }
                 if( $addResolveGroupIPCoverage )
                 {
@@ -792,17 +762,17 @@ ZoneCallContext::$supportedActions['exportToExcel'] = array(
                     foreach( array_keys($mapping->unresolved) as $unresolved )
                         $strMapping[] = $unresolved;
 
-                    $lines .= $encloseFunction($strMapping);
+                    $lines .= $context->encloseFunction($strMapping);
                 }
                 if( $addNestedMembers )
                 {
                     if( $object->isGroup() )
                     {
                         $members = $object->expand(TRUE);
-                        $lines .= $encloseFunction($members);
+                        $lines .= $context->encloseFunction($members);
                     }
                     else
-                        $lines .= $encloseFunction('');
+                        $lines .= $context->encloseFunction('');
                 }
 
                 $lines .= "</tr>\n";

--- a/utils/develop/ui/json_array.js
+++ b/utils/develop/ui/json_array.js
@@ -384,6 +384,38 @@ var subjectObject =
                     }
                 }
             },
+            "upload-address-2cloudmanager": {
+                "name": "upload-address-2cloudmanager",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "panorama_file": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "dg_name": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
+            "upload-addressgroup-2cloudmanager": {
+                "name": "upload-addressgroup-2cloudmanager",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "panorama_file": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "dg_name": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
             "value-host-object-add-netmask-m32": {
                 "name": "value-host-object-add-netmask-m32",
                 "MainFunction": {}
@@ -1803,6 +1835,12 @@ var subjectObject =
                 "name": "template-delete",
                 "MainFunction": {}
             },
+            "xml-extract": {
+                "name": "xml-extract",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {}
+            },
             "zoneprotectionprofile-create-bp": {
                 "name": "zoneprotectionprofile-create-bp",
                 "GlobalInitFunction": {},
@@ -1931,6 +1969,30 @@ var subjectObject =
             "display": {
                 "name": "display",
                 "MainFunction": {}
+            },
+            "exporttoexcel": {
+                "name": "exportToExcel",
+                "MainFunction": {},
+                "GlobalInitFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "filename": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "additionalFields": {
+                        "type": "pipeSeparatedList",
+                        "subtype": "string",
+                        "default": "*NONE*",
+                        "choices": [
+                            "WhereUsed",
+                            "UsedInLocation",
+                            "ResolveIP",
+                            "NestedMembers"
+                        ],
+                        "help": "pipe(|) separated list of additional fields (ie: Arg1|Arg2|Arg3...) to include in the report. The following is available:\n  - NestedMembers: lists all members, even the ones that may be included in nested groups\n  - ResolveIP\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - WhereUsed : list places where object is used (rules, groups ...)\n"
+                    }
+                }
             }
         },
         "filter": {
@@ -6153,9 +6215,10 @@ var subjectObject =
                         "choices": [
                             "WhereUsed",
                             "UsedInLocation",
-                            "ResolveSRV"
+                            "ResolveSRV",
+                            "NestedMembers"
                         ],
-                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - ResolveSRV\n"
+                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - NestedMembers: lists all members, even the ones that may be included in nested groups\n  - ResolveSRV\n"
                     }
                 }
             },
@@ -7652,6 +7715,14 @@ var subjectObject =
             }
         },
         "filter": {
+            "interface": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
             "location": {
                 "operators": {
                     "is": {

--- a/utils/lib/GCP.php
+++ b/utils/lib/GCP.php
@@ -300,7 +300,7 @@ class GCP extends UTIL
 
             $this->execCLIWithOutput( $get_auth );
             $mgmtsvc_tenantID = $this->grepAllPods( "mgmtsvc" );
-            #PH::print_stdout( "mgmtsvc tenantID: '".$mgmtsvc_tenantID[0]."'");
+            PH::print_stdout( "mgmtsvc tenantID: '".$mgmtsvc_tenantID[0]."'");
 
 
             $mgmtsvc = "kubectl exec -it ".$mgmtsvc_tenantID[0]." -c mgmtsvc --insecure-skip-tls-verify=true -- ";

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -856,14 +856,13 @@ class MERGER extends UTIL
                     $skip = false;
 
                     //Todo: check all pickedObjects from hash
-                    /** @var DeviceGroup $pickedObject_DG */
+                    /*
                     $pickedObject_DG = $pickedObject->owner->owner;
                     if( $pickedObject_DG->parentDeviceGroup !== null )
                     {
                         $nextFindObject = $pickedObject_DG->parentDeviceGroup->addressStore->find( $pickedObject->name(), null, True );
                         if( $nextFindObject !== null )
                         {
-                            /** @var Address|AddressGroup $memberFound */
                             if( $pickedObject->isAddress() && $nextFindObject->isAddress() )
                             {
                                 if( $pickedObject->value() !== $nextFindObject->value() )
@@ -890,6 +889,13 @@ class MERGER extends UTIL
                                 break;
                             }
                         }
+                    }
+                    */
+                    $break = $this->checkParentPickObject( $hash );
+                    if( $break )
+                    {
+                        PH::print_stdout("     this object can not be created" );
+                        continue;
                     }
 
                     foreach( $pickedObject->members() as $memberObject )
@@ -958,12 +964,6 @@ class MERGER extends UTIL
                             }
 
                         }
-                    }
-                    $break = $this->checkParentPickObject( $hash );
-                    if( $break )
-                    {
-                        print "this object can not be created\n";
-                        continue;
                     }
 
 

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1238,7 +1238,7 @@ class MERGER extends UTIL
                             else
                             {
                                 */
-                                $this->addressgroupGetValueDiff($ancestor, $object, true);
+                                $this->addressgroupGetValueDiff($childancestor, $object, true);
 
                                 if( isset($childancestor->owner) )
                                 {
@@ -2243,6 +2243,7 @@ class MERGER extends UTIL
                     $hashMap[$value][] = $object;
                     if( $parentStore !== null )
                         $object->ancestor = self::findAncestor( $parentStore, $object, "serviceStore");
+                    $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "serviceStore");
                 }
                 else
                     $upperHashMap[$value][] = $object;
@@ -2538,6 +2539,50 @@ class MERGER extends UTIL
                         continue;
                     }
 
+                    if( isset( $object->childancestor ) )
+                    {
+                        $childancestor = $object->childancestor;
+
+                        if( $childancestor !== null )
+                        {
+                            if( !$childancestor->isGroup() )
+                            {
+                                PH::print_stdout("    - SKIP: object name '{$object->_PANC_shortName()}' as one ancestor is of type: ". get_class( $childancestor )." '{$childancestor->_PANC_shortName()}' value: ".$childancestor->value());
+                                $this->skippedObject( $index, $object, $childancestor, 'childancestor of type: '.get_class( $childancestor ));
+                                break;
+                            }
+
+                            //Todo check ip4mapping of $childancestor and $object
+                            /*
+                            if( $hashGenerator($object) == $hashGenerator($ancestor) )
+                            {
+                                print "additional validation needed if same value\n";
+                                break;
+                            }
+                            else
+                            {
+                                */
+                            $this->servicegroupGetValueDiff($childancestor, $object, true);
+
+                            if( isset($childancestor->owner) )
+                            {
+                                $tmp_ancestor_DGname = $childancestor->owner->owner->name();
+                                if( $tmp_ancestor_DGname === "" )
+                                    $tmp_ancestor_DGname = "shared";
+                            }
+                            else
+                                $tmp_ancestor_DGname = "shared";
+
+
+
+                            PH::print_stdout("    - group '{$object->name()}' cannot be merged because it has an ancestor at DG: ".$tmp_ancestor_DGname );
+                            PH::print_stdout( "    - ancestor type: ".get_class( $childancestor ) );
+                            $this->skippedObject( $index, $object, $childancestor, 'childancestor at DG: '.$tmp_ancestor_DGname);
+
+                            break;
+                            //}
+                        }
+                    }
                     if( $object === $pickedObject )
                     {
                         #PH::print_stdout("    - SKIPPED: '{$object->name()}' === '{$pickedObject->name()}': ");

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -1493,9 +1493,9 @@ class MERGER extends UTIL
                     {
                         $hashMap[$value][] = $object;
                         if( $parentStore !== null )
-                        {
                             $object->ancestor = self::findAncestor( $parentStore, $object, "addressStore" );
-                        }
+
+                        $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "addressStore");
                     }
                     else
                         $upperHashMap[$value][] = $object;
@@ -1521,9 +1521,9 @@ class MERGER extends UTIL
                     {
                         $hashMap[$value][] = $object;
                         if( $parentStore !== null )
-                        {
                             $object->ancestor = self::findAncestor( $parentStore, $object, "addressStore" );
-                        }
+
+                        $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "addressStore");
                     }
                     else
                         $upperHashMap[$value][] = $object;
@@ -2243,6 +2243,7 @@ class MERGER extends UTIL
                     $hashMap[$value][] = $object;
                     if( $parentStore !== null )
                         $object->ancestor = self::findAncestor( $parentStore, $object, "serviceStore");
+
                     $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "serviceStore");
                 }
                 else
@@ -2790,6 +2791,8 @@ class MERGER extends UTIL
                         $hashMap[$value][] = $object;
                         if( $parentStore !== null )
                             $object->ancestor = self::findAncestor($parentStore, $object, "serviceStore");
+
+                        $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "serviceStore");
                     }
                     else
                         $upperHashMap[$value][] = $object;
@@ -2817,6 +2820,7 @@ class MERGER extends UTIL
                         $hashMap[$value][] = $object;
                         if( $parentStore !== null )
                             $object->ancestor = self::findAncestor($parentStore, $object, "serviceStore");
+                        $object->childancestor = self::findChildAncestor( $childDeviceGroups, $object, "serviceStore");
                     }
                     else
                         $upperHashMap[$value][] = $object;

--- a/utils/lib/MERGER.php
+++ b/utils/lib/MERGER.php
@@ -855,6 +855,7 @@ class MERGER extends UTIL
 
                     $skip = false;
 
+                    //Todo: check all pickedObjects from hash
                     /** @var DeviceGroup $pickedObject_DG */
                     $pickedObject_DG = $pickedObject->owner->owner;
                     if( $pickedObject_DG->parentDeviceGroup !== null )
@@ -877,7 +878,7 @@ class MERGER extends UTIL
                                 $diff = $pickedObject->getValueDiff($nextFindObject);
                                 if( count($diff['minus']) != 0 || count($diff['plus']) != 0 )
                                 {
-                                    PH::print_stdout("   * SKIPPED : this group has different member ship compare to upperlevel");
+                                    PH::print_stdout("   * SKIPPED : this group has different membership compare to upperlevel");
                                     $skip = TRUE;
                                     break;
                                 }
@@ -958,6 +959,14 @@ class MERGER extends UTIL
 
                         }
                     }
+                    $break = $this->checkParentPickObject( $hash );
+                    if( $break )
+                    {
+                        print "this object can not be created\n";
+                        continue;
+                    }
+
+
                     if( $skip )
                         continue;
 
@@ -1015,7 +1024,6 @@ class MERGER extends UTIL
                             $this->skippedObject( $index, $pickedObject, $tmp_address, $stringSkippedReason);
                             continue;
                         }
-
                     }
                 }
 
@@ -2018,6 +2026,46 @@ class MERGER extends UTIL
         return $pickedObject;
     }
 
+    function checkParentPickObject( $hash )
+    {
+        $break = False;
+        foreach( $hash as $pickedObject )
+        {
+            /** @var DeviceGroup $pickedObject_DG */
+            $pickedObject_DG = $pickedObject->owner->owner;
+            if( $pickedObject_DG->parentDeviceGroup !== null )
+            {
+                $nextFindObject = $pickedObject_DG->parentDeviceGroup->addressStore->find( $pickedObject->name(), null, True );
+                if( $nextFindObject !== null )
+                {
+                    /** @var Address|AddressGroup $memberFound */
+                    if( $pickedObject->isAddress() && $nextFindObject->isAddress() )
+                    {
+                        if( $pickedObject->value() !== $nextFindObject->value() )
+                        {
+                            PH::print_stdout("   * SKIPPED : this group has an object named '{$pickedObject->name()} that does exist in target location '{$tmp_DG_name}' with different value");
+                            $break = TRUE;
+                        }
+                    }
+                    elseif( $pickedObject->isGroup() && $nextFindObject->isGroup() )
+                    {
+                        $diff = $pickedObject->getValueDiff($nextFindObject);
+                        if( count($diff['minus']) != 0 || count($diff['plus']) != 0 )
+                        {
+                            PH::print_stdout("   * SKIPPED : this group has different membership compare to upperlevel");
+                            $break = TRUE;
+                        }
+                    }
+                    else
+                    {
+                        PH::print_stdout("   * SKIPPED : this group has an object named '{$pickedObject->name()} that does exist in target location '{$tmp_DG_name}' with different object type");
+                        $break = TRUE;
+                    }
+                }
+            }
+        }
+        return $break;
+    }
 
     function servicegroup_merging()
     {

--- a/utils/lib/RULEUTIL.php
+++ b/utils/lib/RULEUTIL.php
@@ -323,7 +323,8 @@ class RULEUTIL extends UTIL
                         }
                         if( array_search('any', $this->ruleTypes) !== FALSE || array_search('defaultsecurity', $this->ruleTypes) !== FALSE )
                         {
-                            $this->objectsToProcess[] = array('store' => $sub->defaultSecurityRules, 'rules' => $sub->defaultSecurityRules->rules());
+                            if( get_class( $sub) !== "Snippet" )
+                                $this->objectsToProcess[] = array('store' => $sub->defaultSecurityRules, 'rules' => $sub->defaultSecurityRules->rules());
                         }
                         if( array_search('any', $this->ruleTypes) !== FALSE || array_search('networkpacketbroker', $this->ruleTypes) !== FALSE )
                         {

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -36,8 +36,10 @@ class RULE_COMPARE extends UTIL
         $this->supportedArguments['file1'] = array('niceName' => 'File1', 'shortHelp' => 'original PAN-OS XML configuration file');
         $this->supportedArguments['file2'] = array('niceName' => 'File2', 'shortHelp' => 'manipulate/optimised former orginal PAN-OS XML configuration file');
 
+        $this->supportedArguments['keepjsonfile1'] = array('niceName' => 'KeepJsonFile1', 'shortHelp' => 'do not delete JsonFile1 at end of script run');
+        $this->supportedArguments['reusejsonfile1'] = array('niceName' => 'ReuseJsonFile1', 'shortHelp' => 'try to reuse an existing JsonFile1 which was not delete by a previous script run');
 
-        $this->usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " in=api:://[MGMT-IP] argument1 [optional_argument2]";
+        $this->usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " file1=original.xml file2=change_config.xml [keepJSONfile1] [reuseJSONfile1]";
 
 
 
@@ -51,12 +53,24 @@ class RULE_COMPARE extends UTIL
         PH::print_stdout();
         PH::print_stdout();
 
+        if( isset(PH::$args['help'] ) )
+        {
+            PH::print_stdout( $this->usageMsg );
+            exit();
+        }
 
         $ruleDiff = FALSE;
 
 
         $type = 'resolved';
         #$type = 'unresolved';
+
+        $keepjsonfile1 = false;
+        if( isset(PH::$args['keepjsonfile1'] ) )
+            $keepjsonfile1 = true;
+        $reusejsonfile1 = false;
+        if( isset(PH::$args['reusejsonfile1'] ) )
+            $reusejsonfile1 = true;
 
         $file1_name = PH::$args['file1'];
         $file2_name = PH::$args['file2'];
@@ -76,24 +90,28 @@ class RULE_COMPARE extends UTIL
             derr("cannot read configuration file '{$file2_name}''", null, FALSE);
 
         ############################################################
-        $shadow_json = "shadow-json";
-        $cli1 = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file1_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file1_name;
-        PH::print_stdout(" - run command: '" . $cli1 . "'");
-        PH::print_stdout();
-        PH::print_stdout("     running this command will take some time");
-        $retValue = null;
-        exec($cli1, $output, $retValue);
-        foreach( $output as $line )
+        if( !$reusejsonfile1 )
         {
-            $string = '   ##  ';
-            $string .= $line;
-            #PH::print_stdout( $string );
+            $shadow_json = "shadow-json";
+            $cli1 = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file1_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file1_name;
+            PH::print_stdout(" - run command: '" . $cli1 . "'");
+            PH::print_stdout();
+            PH::print_stdout("     running this command will take some time");
+            $retValue = null;
+            exec($cli1, $output, $retValue);
+            foreach( $output as $line )
+            {
+                $string = '   ##  ';
+                $string .= $line;
+                #PH::print_stdout( $string );
+            }
+
+            if( $retValue != 0 )
+                derr("CLI exit with error code '{$retValue}'");
+
+            PH::print_stdout();
         }
 
-        if( $retValue != 0 )
-            derr("CLI exit with error code '{$retValue}'");
-
-        PH::print_stdout();
 
         ############################################################
         $shadow_json = "shadow-json";
@@ -119,6 +137,9 @@ class RULE_COMPARE extends UTIL
         ############################################################
         #$file1 = file_get_contents($file1_name);
         #$file2 = file_get_contents($file2_name);
+
+        if( !file_exists($json_file1_name) )
+            derr("cannot read JSON filename1 '{$json_file1_name}''", null, FALSE);
 
         PH::print_stdout("compare JSON filename1: " . $json_file1_name);
         PH::print_stdout("with    JSON filename2: " . $json_file2_name);
@@ -255,7 +276,9 @@ class RULE_COMPARE extends UTIL
             PH::$JSON_OUT['rule-compare'] = $finalArray;
 
         //cleanup
-        unlink($json_file1_name);
+        if( !$keepjsonfile1 )
+            unlink($json_file1_name);
+
         unlink($json_file2_name);
         unset($file1);
         unset($file2);

--- a/utils/lib/RULE_COMPARE.php
+++ b/utils/lib/RULE_COMPARE.php
@@ -39,7 +39,7 @@ class RULE_COMPARE extends UTIL
         $this->supportedArguments['keepjsonfile1'] = array('niceName' => 'KeepJsonFile1', 'shortHelp' => 'do not delete JsonFile1 at end of script run');
         $this->supportedArguments['reusejsonfile1'] = array('niceName' => 'ReuseJsonFile1', 'shortHelp' => 'try to reuse an existing JsonFile1 which was not delete by a previous script run');
 
-        $this->usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " file1=original.xml file2=change_config.xml [keepJSONfile1] [reuseJSONfile1]";
+        $this->usageMsg = PH::boldText('USAGE: ') . "php " . basename(__FILE__) . " file1=original.xml file2=change_config.xml [keepJSONfile1] [reuseJSONfile1] [generateRuleHTMLFile]";
 
 
 
@@ -71,6 +71,9 @@ class RULE_COMPARE extends UTIL
         $reusejsonfile1 = false;
         if( isset(PH::$args['reusejsonfile1'] ) )
             $reusejsonfile1 = true;
+        $generateRuleHTMLfile = false;
+        if( isset(PH::$args['generaterulehtmlfile'] ) )
+            $generateRuleHTMLfile = true;
 
         $file1_name = PH::$args['file1'];
         $file2_name = PH::$args['file2'];
@@ -92,53 +95,20 @@ class RULE_COMPARE extends UTIL
         ############################################################
         if( !$reusejsonfile1 )
         {
-            $shadow_json = "shadow-json";
-            $cli1 = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file1_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file1_name;
-            PH::print_stdout(" - run command: '" . $cli1 . "'");
-            PH::print_stdout();
-            PH::print_stdout("     running this command will take some time");
-            $retValue = null;
-            exec($cli1, $output, $retValue);
-            foreach( $output as $line )
-            {
-                $string = '   ##  ';
-                $string .= $line;
-                #PH::print_stdout( $string );
-            }
-
-            if( $retValue != 0 )
-                derr("CLI exit with error code '{$retValue}'");
-
-            PH::print_stdout();
+            $this->createJson( $file1_name, $json_file1_name);
         }
+        else
+            PH::print_stdout( "JSON file1 will be reuse" );
 
 
         ############################################################
-        $shadow_json = "shadow-json";
-        $cli2 = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file2_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file2_name;
-        PH::print_stdout(" - run command: '" . $cli2 . "'");
-        PH::print_stdout();
-        PH::print_stdout("     running this command will take some time");
-        $retValue = null;
-        exec($cli2, $output, $retValue);
-        foreach( $output as $line )
-        {
-            $string = '   ##  ';
-            $string .= $line;
-
-            #PH::print_stdout( $string );
-        }
-
-        if( $retValue != 0 )
-            derr("CLI exit with error code '{$retValue}'");
-
-        PH::print_stdout();
+        $this->createJson( $file2_name, $json_file2_name);
 
         ############################################################
         #$file1 = file_get_contents($file1_name);
         #$file2 = file_get_contents($file2_name);
 
-        if( !file_exists($json_file1_name) )
+        if( !file_exists($json_file1_name) || filesize($json_file1_name) === 0 )
             derr("cannot read JSON filename1 '{$json_file1_name}''", null, FALSE);
 
         PH::print_stdout("compare JSON filename1: " . $json_file1_name);
@@ -223,6 +193,7 @@ class RULE_COMPARE extends UTIL
 
                     PH::print_stdout("--------------------------------------------------");
                     PH::print_stdout("SUB: '" . $subName . "' | Rule diff found: '" . PH::boldText($key)."'");
+
                     $finalArray[$subName][$key] = array();
                     if( !empty($diff_src) )
                     {
@@ -249,6 +220,13 @@ class RULE_COMPARE extends UTIL
                         PH::print_stdout( PH::boldText("  ".$keyword) );
                         $this->printArray($srv1, $srv2, $compareArray);
                         $finalArray[$subName][$key][$keyword] = $compareArray;
+                    }
+
+                    if( $generateRuleHTMLfile )
+                    {
+                        PH::print_stdout( "create HTML file");
+                        $this->generateRuleHTMLfile( $file1_name, $subName, $key );
+                        $this->generateRuleHTMLfile( $file2_name, $subName, $key );
                     }
                 }
             }
@@ -370,5 +348,44 @@ class RULE_COMPARE extends UTIL
             $compareArray['file1'] = array();
             $compareArray['file2'] = array();
         }
+    }
+
+    function createJson( $file_name, $json_file_name)
+    {
+        $shadow_json = "shadow-json";
+        $cli = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=display:ResolveAddressSummary|ResolveServiceSummary' location=any in=" . $file_name . " " . $shadow_json . " shadow-ignoreinvalidaddressobjects | tee " . $json_file_name;
+
+        $this->executeCommand( $cli );
+
+        PH::print_stdout();
+    }
+
+    function generateRuleHTMLfile( $file_name, $subName, $key )
+    {
+        $shadow_json = "";
+        $spreadsheetFiletype = "html";
+        $cli = "php " . dirname(__FILE__) . "/../../utils/pan-os-php.php type=rule 'actions=exporttoexcel:".$file_name."_".$subName."_".$key.".".$spreadsheetFiletype.",ResolveAddressSummary|ResolveServiceSummary' 'location=".$subName."' in=" . $file_name . " 'filter=(name eq ".$key.")'" . $shadow_json . " shadow-ignoreinvalidaddressobjects";
+
+        $this->executeCommand( $cli );
+
+        PH::print_stdout();
+    }
+
+    function executeCommand( $cli )
+    {
+        PH::print_stdout(" - run command: '" . $cli . "'");
+        PH::print_stdout();
+        PH::print_stdout("     running this command will take some time");
+        $retValue = null;
+        exec($cli, $output, $retValue);
+        foreach( $output as $line )
+        {
+            $string = '   ##  ';
+            $string .= $line;
+            #PH::print_stdout( $string );
+        }
+
+        if( $retValue != 0 )
+            derr("CLI exit with error code '{$retValue}'");
     }
 }

--- a/utils/lib/UTIL.php
+++ b/utils/lib/UTIL.php
@@ -1210,7 +1210,7 @@ class UTIL
                 elseif( $this->configInput['type'] == 'sase-api' )
                 {
                     $context->isAPI = TRUE;
-                    #$context->isSaseAPI = TRUE;
+                    $context->isSaseAPI = TRUE;
                 }
 
 

--- a/utils/lib/util_action_filter.json
+++ b/utils/lib/util_action_filter.json
@@ -383,6 +383,38 @@
                     }
                 }
             },
+            "upload-address-2cloudmanager": {
+                "name": "upload-address-2cloudmanager",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "panorama_file": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "dg_name": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
+            "upload-addressgroup-2cloudmanager": {
+                "name": "upload-addressgroup-2cloudmanager",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "panorama_file": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "dg_name": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    }
+                }
+            },
             "value-host-object-add-netmask-m32": {
                 "name": "value-host-object-add-netmask-m32",
                 "MainFunction": {}
@@ -1802,6 +1834,12 @@
                 "name": "template-delete",
                 "MainFunction": {}
             },
+            "xml-extract": {
+                "name": "xml-extract",
+                "GlobalInitFunction": {},
+                "MainFunction": {},
+                "GlobalFinishFunction": {}
+            },
             "zoneprotectionprofile-create-bp": {
                 "name": "zoneprotectionprofile-create-bp",
                 "GlobalInitFunction": {},
@@ -1930,6 +1968,30 @@
             "display": {
                 "name": "display",
                 "MainFunction": {}
+            },
+            "exporttoexcel": {
+                "name": "exportToExcel",
+                "MainFunction": {},
+                "GlobalInitFunction": {},
+                "GlobalFinishFunction": {},
+                "args": {
+                    "filename": {
+                        "type": "string",
+                        "default": "*nodefault*"
+                    },
+                    "additionalFields": {
+                        "type": "pipeSeparatedList",
+                        "subtype": "string",
+                        "default": "*NONE*",
+                        "choices": [
+                            "WhereUsed",
+                            "UsedInLocation",
+                            "ResolveIP",
+                            "NestedMembers"
+                        ],
+                        "help": "pipe(|) separated list of additional fields (ie: Arg1|Arg2|Arg3...) to include in the report. The following is available:\n  - NestedMembers: lists all members, even the ones that may be included in nested groups\n  - ResolveIP\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - WhereUsed : list places where object is used (rules, groups ...)\n"
+                    }
+                }
             }
         },
         "filter": {
@@ -6152,9 +6214,10 @@
                         "choices": [
                             "WhereUsed",
                             "UsedInLocation",
-                            "ResolveSRV"
+                            "ResolveSRV",
+                            "NestedMembers"
                         ],
-                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - ResolveSRV\n"
+                        "help": "pipe(|) separated list of additional field to include in the report. The following is available:\n  - WhereUsed : list places where object is used (rules, groups ...)\n  - UsedInLocation : list locations (vsys,dg,shared) where object is used\n  - NestedMembers: lists all members, even the ones that may be included in nested groups\n  - ResolveSRV\n"
                     }
                 }
             },
@@ -7651,6 +7714,14 @@
             }
         },
         "filter": {
+            "interface": {
+                "operators": {
+                    "is.set": {
+                        "Function": {},
+                        "arg": false
+                    }
+                }
+            },
             "location": {
                 "operators": {
                     "is": {


### PR DESCRIPTION
## Description

UTIL:
* type=address | introduction of actions=upload-address-2cloudmanager:panorama.xml,DGname && actions=upload-addressgroup-2cloudmanager:panorama.xml,DGname
* type=address actions=upload-address-2cloudmanager | extend validation if object name is already available
* type=servicegroup-merger | introduce validation extension for childDG merger
* type=rule-compare | exend with argument 'keepJSONfile1' and 'reuseJSONfile1'
* type=rule-compare | introduce argument 'generateRuleHtmlFile'
* type=servicegroup-merger | extend with childancestor validation
* type=service actions=exporttoexcel:file.html | introduce additional arguments nestedmembers
* type=XYZ actions=exporttoexcel:file.html | use single function to create spreadsheet content
* type=dhcp | introduce actions=exporttoexcel:file.html
* type=dhcp | improvement for actions=exporttoexcel
* type=dhcp actions=display/exporttoexcel | extend with additional DHCP information
* type=rule 'actions=exporttoexcel:file.html,resovleservicesummary' | extend with column service_resolve_nested/_name/_value/_location
* type=service actions=exporttoexcel:file.html | correct predefined service-http/-https output
* type=address/server actions=exporttoexcel:file.html,nestedmembers | extend with column nested members location
* class Address - use $RuleReferenceLocation
* type=zone | introduce 'filter=(interface is.set)'

BUGFIX:
* class Region | bugfix - introduce method type() - to handle "type=address actions="
* type=address actions=move - bugifx/workaround - do not move region objects
* type=addressgroup-merger | bugfix to check childancestor objects availability
* type=addressgroup-merger | bugfix if multiple childDG has same objectgroup incl. value, but one differ; stop merging
* class AddressGroup  | bugfix for method expand() - to correctly extract all submembers and their value for type=rule 'actions=exporttoexcel:file.html,resolveaddresssummary'
* type=address actions=exporttoexcel:file.html | bugfix to crash for tmp objects
* type=dhcp actions=exporttoexcel | bugfix to add correct template
* class PH - workaround for none working API mode connector - discard setType()
* class RULEUTIL - defaultSecurityRules not available in Fawkes Snippet
* type=rule - actions=display/exporttoexcel:resolveaddresssummary | add new src/dst_resovled_sum - for better nested calculation

GENERAL:
* PAN-OS dynamic content update to version  8741-8213