### PR TITLE
version 2.1.18 - bugfix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,14 @@
 CHANGELOG
 
-2.1.17
+2.1.18
+UTIL:
+
+BUGFIX:
+
+GENERAL:
+
+
+2.1.17 (20230920)
 UTIL:
 * type=certificate | extend to TemplateStack
 * introduce class SharedGatewayStore | extend different classes to support SharedGateway

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ CHANGELOG
 UTIL:
 
 BUGFIX:
+* type=address/service 'actions=move:shared,skipIfConflict' | bugfix as variable $findSubSystem was not declared for targetlocation 'shared'
 
 GENERAL:
 

--- a/lib/misc-classes/PH.php
+++ b/lib/misc-classes/PH.php
@@ -182,7 +182,7 @@ class PH
 
     private static $library_version_major = 2;
     private static $library_version_sub = 1;
-    private static $library_version_bugfix = 17;
+    private static $library_version_bugfix = 18;
 
     //BASIC AUTH PAN-OS 7.1
     public static $softwareupdate_key = "658d787f293e631196dac9fb29490f1cc1bb3827";

--- a/utils/common/actions-address.php
+++ b/utils/common/actions-address.php
@@ -1451,6 +1451,7 @@ AddressCallContext::$supportedActions[] = array(
 
         if( $targetLocation == 'shared' )
         {
+            $findSubSystem = $rootObject;
             $targetStore = $rootObject->addressStore;
         }
         else

--- a/utils/common/actions-service.php
+++ b/utils/common/actions-service.php
@@ -573,6 +573,7 @@ ServiceCallContext::$supportedActions[] = array(
 
         if( $targetLocation == 'shared' )
         {
+            $findSubSystem = $rootObject;
             $targetStore = $rootObject->serviceStore;
         }
         else


### PR DESCRIPTION
## Description

BUGFIX:
* type=address/service 'actions=move:shared,skipIfConflict' | bugfix as variable $findSubSystem was not declared for targetlocation 'shared'