### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/arm_docker-image-push.yml
+++ b/.github/workflows/arm_docker-image-push.yml
@@ -17,12 +17,12 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # -
+      #   name: Login to Docker Hub
+      #   uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
@@ -34,7 +34,7 @@ jobs:
           context: .
           file: docker/Dockerfile-main_arm64v8
           platforms: linux/arm64
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-arm:${{ secrets.DOCKER_HUB_TAG }}
 
       -
@@ -44,7 +44,7 @@ jobs:
           context: .
           file: docker/Dockerfile-php_arm64v8
           platforms: linux/arm64
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-cli-arm:${{ secrets.DOCKER_HUB_TAG }}
 
       -
@@ -54,5 +54,5 @@ jobs:
           context: .
           file: docker/Dockerfile-API_arm64v8
           platforms: linux/arm64
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-api-arm:${{ secrets.DOCKER_HUB_TAG }}

--- a/.github/workflows/arm_docker-image-push.yml
+++ b/.github/workflows/arm_docker-image-push.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
 
       -
-        name: Build and push pan-os-php-arm
+        name: Build pan-os-php-arm
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
@@ -38,7 +38,7 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-arm:${{ secrets.DOCKER_HUB_TAG }}
 
       -
-        name: Build and push pan-os-php-cli-arm
+        name: Build pan-os-php-cli-arm
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
@@ -48,7 +48,7 @@ jobs:
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-cli-arm:${{ secrets.DOCKER_HUB_TAG }}
 
       -
-        name: Build and push pan-os-php-api-arm
+        name: Build pan-os-php-api-arm
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .

--- a/.github/workflows/arm_docker-image-push.yml
+++ b/.github/workflows/arm_docker-image-push.yml
@@ -29,7 +29,7 @@ jobs:
 
       -
         name: Build and push pan-os-php-arm
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-main_arm64v8
@@ -39,7 +39,7 @@ jobs:
 
       -
         name: Build and push pan-os-php-cli-arm
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-php_arm64v8

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -17,48 +17,48 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # -
+      #   name: Login to Docker Hub
+      #   uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
 
       -
-        name: Build and push pan-os-php-amd
+        name: Build pan-os-php-amd
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-main_amd
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-amd:${{ secrets.DOCKER_HUB_TAG }}
 
       -
-        name: Build and push pan-os-php-cli-amd
+        name: Build pan-os-php-cli-amd
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-php_amd
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-cli-amd:${{ secrets.DOCKER_HUB_TAG }}
 
       -
-        name: Build and push pan-os-php-api-amd
+        name: Build pan-os-php-api-amd
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-API_amd
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-api-amd:${{ secrets.DOCKER_HUB_TAG }}
 
       -
-        name: Build and push pan-os-php-cli_php8_2
+        name: Build pan-os-php-cli_php8_2
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-cli-ubuntu22-php8_2
-          push: true
+          push: false
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pan-os-php-cli_php8_2:${{ secrets.DOCKER_HUB_TAG }}

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -29,7 +29,7 @@ jobs:
 
       -
         name: Build and push pan-os-php-amd
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-main_amd
@@ -38,7 +38,7 @@ jobs:
 
       -
         name: Build and push pan-os-php-cli-amd
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-php_amd
@@ -47,7 +47,7 @@ jobs:
 
       -
         name: Build and push pan-os-php-api-amd
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           file: docker/Dockerfile-API_amd


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions